### PR TITLE
Particles!

### DIFF
--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD11D82A1A815AD3004F1197 /* Particle.swift */; };
 		CD26ECC61A83CE1000E8EC3B /* Radian.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD26ECC51A83CE1000E8EC3B /* Radian.swift */; };
 		CD26ECCB1A83FECC00E8EC3B /* ParticleEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD26ECCA1A83FECC00E8EC3B /* ParticleEmitter.swift */; };
+		CD3F93A01A852AF500B964FC /* ParticlePreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3F939F1A852AF500B964FC /* ParticlePreset.swift */; };
 		EB04E5CA1A6606D100FD1EE3 /* KFTunableSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB04E5CB1A6606D100FD1EE3 /* KFTunableSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */; };
 		EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */; };
@@ -130,6 +131,7 @@
 		CD11D82A1A815AD3004F1197 /* Particle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Particle.swift; sourceTree = "<group>"; };
 		CD26ECC51A83CE1000E8EC3B /* Radian.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Radian.swift; sourceTree = "<group>"; };
 		CD26ECCA1A83FECC00E8EC3B /* ParticleEmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticleEmitter.swift; sourceTree = "<group>"; };
+		CD3F939F1A852AF500B964FC /* ParticlePreset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticlePreset.swift; sourceTree = "<group>"; };
 		EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KFTunableSpec.h; path = ThirdParty/TunableSpec/KFTunableSpec.h; sourceTree = "<group>"; };
 		EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KFTunableSpec.m; path = ThirdParty/TunableSpec/KFTunableSpec.m; sourceTree = "<group>"; };
 		EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TunableSpec.swift; path = ThirdParty/TunableSpec/TunableSpec.swift; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				EBA8371B1A1DB51000D23C9D /* Sound.swift */,
 				CD11D82A1A815AD3004F1197 /* Particle.swift */,
 				CD26ECCA1A83FECC00E8EC3B /* ParticleEmitter.swift */,
+				CD3F939F1A852AF500B964FC /* ParticlePreset.swift */,
 				9EC148211A20FB1C004C7129 /* ThirdParty */,
 				EBB3505D1A166E5E0046AD07 /* Utilities */,
 				EBE3A75819DF79C400A77736 /* Supporting Files */,
@@ -535,6 +538,7 @@
 			files = (
 				EBE3A77519DF79E900A77736 /* Layer.swift in Sources */,
 				CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */,
+				CD3F93A01A852AF500B964FC /* ParticlePreset.swift in Sources */,
 				CD26ECCB1A83FECC00E8EC3B /* ParticleEmitter.swift in Sources */,
 				EB8BC1CA1A2CE7B5005E799C /* Border.swift in Sources */,
 				EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */,

--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD11D82A1A815AD3004F1197 /* Particle.swift */; };
 		CD26ECC61A83CE1000E8EC3B /* Radian.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD26ECC51A83CE1000E8EC3B /* Radian.swift */; };
+		CD26ECCB1A83FECC00E8EC3B /* ParticleEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD26ECCA1A83FECC00E8EC3B /* ParticleEmitter.swift */; };
 		EB04E5CA1A6606D100FD1EE3 /* KFTunableSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB04E5CB1A6606D100FD1EE3 /* KFTunableSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */; };
 		EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */; };
@@ -128,6 +129,7 @@
 /* Begin PBXFileReference section */
 		CD11D82A1A815AD3004F1197 /* Particle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Particle.swift; sourceTree = "<group>"; };
 		CD26ECC51A83CE1000E8EC3B /* Radian.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Radian.swift; sourceTree = "<group>"; };
+		CD26ECCA1A83FECC00E8EC3B /* ParticleEmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticleEmitter.swift; sourceTree = "<group>"; };
 		EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KFTunableSpec.h; path = ThirdParty/TunableSpec/KFTunableSpec.h; sourceTree = "<group>"; };
 		EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KFTunableSpec.m; path = ThirdParty/TunableSpec/KFTunableSpec.m; sourceTree = "<group>"; };
 		EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TunableSpec.swift; path = ThirdParty/TunableSpec/TunableSpec.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				EBA837161A1DADDF00D23C9D /* Heartbeat.swift */,
 				EBA8371B1A1DB51000D23C9D /* Sound.swift */,
 				CD11D82A1A815AD3004F1197 /* Particle.swift */,
+				CD26ECCA1A83FECC00E8EC3B /* ParticleEmitter.swift */,
 				9EC148211A20FB1C004C7129 /* ThirdParty */,
 				EBB3505D1A166E5E0046AD07 /* Utilities */,
 				EBE3A75819DF79C400A77736 /* Supporting Files */,
@@ -532,6 +535,7 @@
 			files = (
 				EBE3A77519DF79E900A77736 /* Layer.swift in Sources */,
 				CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */,
+				CD26ECCB1A83FECC00E8EC3B /* ParticleEmitter.swift in Sources */,
 				EB8BC1CA1A2CE7B5005E799C /* Border.swift in Sources */,
 				EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */,
 				EB04E5D21A6606DE00FD1EE3 /* Tunable.swift in Sources */,

--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD11D82A1A815AD3004F1197 /* Particle.swift */; };
 		EB04E5CA1A6606D100FD1EE3 /* KFTunableSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB04E5CB1A6606D100FD1EE3 /* KFTunableSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */; };
 		EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */; };
@@ -124,6 +125,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CD11D82A1A815AD3004F1197 /* Particle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Particle.swift; sourceTree = "<group>"; };
 		EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KFTunableSpec.h; path = ThirdParty/TunableSpec/KFTunableSpec.h; sourceTree = "<group>"; };
 		EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KFTunableSpec.m; path = ThirdParty/TunableSpec/KFTunableSpec.m; sourceTree = "<group>"; };
 		EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TunableSpec.swift; path = ThirdParty/TunableSpec/TunableSpec.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				EBBA431619F45186000B81BE /* Gesture.swift */,
 				EBA837161A1DADDF00D23C9D /* Heartbeat.swift */,
 				EBA8371B1A1DB51000D23C9D /* Sound.swift */,
+				CD11D82A1A815AD3004F1197 /* Particle.swift */,
 				9EC148211A20FB1C004C7129 /* ThirdParty */,
 				EBB3505D1A166E5E0046AD07 /* Utilities */,
 				EBE3A75819DF79C400A77736 /* Supporting Files */,
@@ -525,6 +528,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EBE3A77519DF79E900A77736 /* Layer.swift in Sources */,
+				CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */,
 				EB8BC1CA1A2CE7B5005E799C /* Border.swift in Sources */,
 				EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */,
 				EB04E5D21A6606DE00FD1EE3 /* Tunable.swift in Sources */,

--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		CD11D82B1A815AD3004F1197 /* Particle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD11D82A1A815AD3004F1197 /* Particle.swift */; };
+		CD26ECC61A83CE1000E8EC3B /* Radian.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD26ECC51A83CE1000E8EC3B /* Radian.swift */; };
 		EB04E5CA1A6606D100FD1EE3 /* KFTunableSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB04E5CB1A6606D100FD1EE3 /* KFTunableSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */; };
 		EB04E5CC1A6606D100FD1EE3 /* TunableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */; };
@@ -126,6 +127,7 @@
 
 /* Begin PBXFileReference section */
 		CD11D82A1A815AD3004F1197 /* Particle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Particle.swift; sourceTree = "<group>"; };
+		CD26ECC51A83CE1000E8EC3B /* Radian.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Radian.swift; sourceTree = "<group>"; };
 		EB04E5C71A6606D100FD1EE3 /* KFTunableSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KFTunableSpec.h; path = ThirdParty/TunableSpec/KFTunableSpec.h; sourceTree = "<group>"; };
 		EB04E5C81A6606D100FD1EE3 /* KFTunableSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KFTunableSpec.m; path = ThirdParty/TunableSpec/KFTunableSpec.m; sourceTree = "<group>"; };
 		EB04E5C91A6606D100FD1EE3 /* TunableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TunableSpec.swift; path = ThirdParty/TunableSpec/TunableSpec.swift; sourceTree = "<group>"; };
@@ -313,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				EBB3505E1A166E690046AD07 /* Dictionary+Extensions.swift */,
+				CD26ECC51A83CE1000E8EC3B /* Radian.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -537,6 +540,7 @@
 				EBB3505F1A166E690046AD07 /* Dictionary+Extensions.swift in Sources */,
 				EBABE67D19E4AEF100483EEF /* Geometry.swift in Sources */,
 				EBB565DB19F074B000D93DE3 /* Math.swift in Sources */,
+				CD26ECC61A83CE1000E8EC3B /* Radian.swift in Sources */,
 				EB04E5CB1A6606D100FD1EE3 /* KFTunableSpec.m in Sources */,
 				EB1C2A6519E4B534000DC2C1 /* Color.swift in Sources */,
 				EBF59A941A2E2B5000AB8C67 /* Shadow.swift in Sources */,

--- a/Prototope/Color.swift
+++ b/Prototope/Color.swift
@@ -11,6 +11,10 @@ import UIKit
 /** A simple representation of color. */
 public struct Color {
 	let uiColor: UIColor
+	
+	var CGColor: CGColorRef {
+		return self.uiColor.CGColor
+	}
 
 	/** Constructs a color from RGB and alpha values. Arguments range from 0.0 to 1.0. */
 	public init(red: Double, green: Double, blue: Double, alpha: Double = 1.0) {

--- a/Prototope/Color.swift
+++ b/Prototope/Color.swift
@@ -12,6 +12,7 @@ import UIKit
 public struct Color {
 	let uiColor: UIColor
 	
+	/** The underlying CGColor of this colour. */
 	var CGColor: CGColorRef {
 		return self.uiColor.CGColor
 	}

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -387,6 +387,9 @@ public class Layer: Equatable, Hashable {
 	public func addParticleEmitter(particleEmitter: ParticleEmitter) {
 		self.particleEmitters.append(particleEmitter)
 		self.view.layer.addSublayer(particleEmitter.emitterLayer)
+		particleEmitter.emitterLayer.frame = self.view.layer.bounds
+		particleEmitter.size = self.size
+		particleEmitter.position = Point(particleEmitter.emitterLayer.position)
 		
 		// TODO(jb): Should we disable bounds clipping on self.view.layer or instruct devs to instead emit the particles from a parent layer?
 		self.view.layer.masksToBounds = false

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -375,6 +375,32 @@ public class Layer: Equatable, Hashable {
 		get { return view.userInteractionEnabled }
 		set { view.userInteractionEnabled = newValue }
 	}
+	
+	
+	// MARK: Particles
+	
+	/** An array of the layer's particle emitters. */
+	private var particleEmitters: [ParticleEmitter] = []
+	
+	
+	/** Adds the particle emitter to the layer. */
+	public func addParticleEmitter(particleEmitter: ParticleEmitter) {
+		self.particleEmitters.append(particleEmitter)
+		self.view.layer.addSublayer(particleEmitter.emitterLayer)
+		
+		// TODO(jb): Should we disable bounds clipping on self.view.layer or instruct devs to instead emit the particles from a parent layer?
+		self.view.layer.masksToBounds = false
+	}
+	
+	
+	/** Removes the given particle emitter from the layer. */
+	public func removeParticleEmitter(particleEmitter: ParticleEmitter) {
+		particleEmitter.emitterLayer.removeFromSuperlayer()
+		self.particleEmitters = self.particleEmitters.filter {
+			(emitter: ParticleEmitter) -> Bool in
+			return emitter !== particleEmitter
+		}
+	}
 
 	// MARK: Touches and gestures
 

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -384,7 +384,7 @@ public class Layer: Equatable, Hashable {
 	
 	
 	/** Adds the particle emitter to the layer. */
-	public func addParticleEmitter(particleEmitter: ParticleEmitter) {
+	public func addParticleEmitter(particleEmitter: ParticleEmitter, forDuration duration: TimeInterval? = nil) {
 		self.particleEmitters.append(particleEmitter)
 		self.view.layer.addSublayer(particleEmitter.emitterLayer)
 		particleEmitter.emitterLayer.frame = self.view.layer.bounds
@@ -393,6 +393,12 @@ public class Layer: Equatable, Hashable {
 		
 		// TODO(jb): Should we disable bounds clipping on self.view.layer or instruct devs to instead emit the particles from a parent layer?
 		self.view.layer.masksToBounds = false
+		
+		if let duration = duration {
+			afterDuration(duration, { () -> Void in
+				self.removeParticleEmitter(particleEmitter)
+			})
+		}
 	}
 	
 	

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -397,9 +397,9 @@ public class Layer: Equatable, Hashable {
 		self.view.layer.masksToBounds = false
 		
 		if let duration = duration {
-			afterDuration(duration, { () -> Void in
+			afterDuration(duration) {
 				self.removeParticleEmitter(particleEmitter)
-			})
+			}
 		}
 	}
 	

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -55,7 +55,7 @@ public enum ParticlePreset {
 public struct Particle {
 	
 	let image: Image
-	private let emitterCell: CAEmitterCell
+	let emitterCell: CAEmitterCell
 	
 	
 	public init(image: Image, preset: ParticlePreset) {
@@ -183,21 +183,3 @@ public struct Particle {
 	
 }
 
-
-extension Layer {
-	
-	public func emitParticle(particle: Particle) {
-		let emitter = CAEmitterLayer()
-		emitter.birthRate = 1
-		emitter.emitterCells = [particle.emitterCell]
-		emitter.renderMode = kCAEmitterLayerAdditive
-		emitter.frame = self.view.layer.bounds
-		emitter.emitterShape = kCAEmitterLayerLine
-
-		self.view.layer.addSublayer(emitter)
-		self.view.clipsToBounds = false
-		
-		emitter.emitterPosition = emitter.position
-		emitter.emitterSize = emitter.bounds.size
-	}
-}

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -26,7 +26,7 @@ public struct Particle {
 		
 		self.velocity = 100
 		
-		self.emissionRangeInRadians = M_PI * 2.0
+		self.emissionRange = M_PI * 2.0
 		
 		self.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
 		
@@ -70,7 +70,7 @@ public struct Particle {
 	/** The emission range, in radians. Particles are uniformly distributed in this range.
 		
 		Set to a full circle (2π) for a full circular range. */
-	public var emissionRangeInRadians: Double {
+	public var emissionRange: Radian {
 		get { return Double(self.emitterCell.emissionRange) }
 		set { self.emitterCell.emissionRange = CGFloat(newValue) }
 	}

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -19,21 +19,92 @@ public struct Particle {
 		self.emitterCell = CAEmitterCell()
 		self.emitterCell.contents = self.image.uiImage.CGImage
 		
-		self.emitterCell.lifetime = 3
-		self.emitterCell.lifetimeRange = 3
+		self.lifetime = 3
+		self.lifetimeRange = 3
 		
-		self.emitterCell.birthRate = 80
+		self.birthRate = 80
 		
-		self.emitterCell.velocity = 100
+		self.velocity = 100
 		
-		self.emitterCell.emissionRange = CGFloat(M_PI) * 2.0
+		self.emissionRangeInRadians = M_PI * 2.0
 		
-		self.emitterCell.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0).CGColor
+		self.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
 		
-		self.emitterCell.redRange = 1.0
-		self.emitterCell.blueRange = 1.0
-		self.emitterCell.greenRange = 1.0
-		self.emitterCell.alphaRange = 1.0
+		self.redRange = 1.0
+		self.blueRange = 1.0
+		self.greenRange = 1.0
+		self.alphaRange = 1.0
+	}
+	
+	
+	// MARK: - Particle properties
+	
+	/** The lifetime, in seconds, of particles. */
+	public var lifetime: Double {
+		get { return Double(self.emitterCell.lifetime) }
+		set { self.emitterCell.lifetime = Float(newValue) }
+	}
+	
+	
+	/** The range of variation for the particle's lifetime. */
+	public var lifetimeRange: Double {
+		get { return Double(self.emitterCell.lifetimeRange) }
+		set { self.emitterCell.lifetimeRange = Float(newValue) }
+	}
+	
+	
+	/** The birth rate, in particle / second, for new particles. */
+	public var birthRate: Double {
+		get { return Double(self.emitterCell.birthRate) }
+		set { self.emitterCell.birthRate = Float(newValue) }
+	}
+	
+	
+	/** The velocity of particles. */
+	public var velocity: Double {
+		get { return Double(self.emitterCell.velocity) }
+		set { self.emitterCell.velocity = CGFloat(newValue) }
+	}
+	
+	
+	/** The emission range, in radians. Particles are uniformly distributed in this range.
+		
+		Set to a full circle (2π) for a full circular range. */
+	public var emissionRangeInRadians: Double {
+		get { return Double(self.emitterCell.emissionRange) }
+		set { self.emitterCell.emissionRange = CGFloat(newValue) }
+	}
+	
+	
+	/** The colour of the particle. */
+	public var color: Color {
+		get { return Color(UIColor(CGColor: self.emitterCell.color)) }
+		set { self.emitterCell.color = newValue.CGColor }
+	}
+	
+	
+	/** The range of red in the particle. */
+	public var redRange: Double {
+		get { return Double(self.emitterCell.redRange) }
+		set { self.emitterCell.redRange = Float(newValue) }
+	}
+	
+	/** The range of blue in the particle. */
+	public var blueRange: Double {
+		get { return Double(self.emitterCell.blueRange) }
+		set { self.emitterCell.blueRange = Float(newValue) }
+	}
+	
+	/** The range of green in the particle. */
+	public var greenRange: Double {
+		get { return Double(self.emitterCell.greenRange) }
+		set { self.emitterCell.greenRange = Float(newValue) }
+	}
+	
+	/** The range of alpha in the particle. */
+	public var alphaRange: Double {
+		get { return Double(self.emitterCell.alphaRange) }
+		set { self.emitterCell.alphaRange = Float(newValue) }
 	}
 }
 
@@ -44,7 +115,7 @@ extension Layer {
 		let emitter = CAEmitterLayer()
 		emitter.birthRate = 1
 		emitter.emitterCells = [particle.emitterCell]
-		emitter.emitterMode = kCAEmitterLayerAdditive
+//		emitter.emitterMode = kCAEmitterLayerAdditive
 		
 		self.view.layer.addSublayer(emitter)
 		self.view.clipsToBounds = false

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -1,0 +1,52 @@
+//
+//  Particle.swift
+//  Prototope
+//
+//  Created by Jason Brennan on Feb-03-2015.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import UIKit
+
+public struct Particle {
+	
+	let image: Image
+	private let emitterCell: CAEmitterCell
+	
+	public init(image: Image) {
+		self.image = image
+		
+		self.emitterCell = CAEmitterCell()
+		self.emitterCell.contents = self.image.uiImage.CGImage
+		
+		self.emitterCell.lifetime = 3
+		self.emitterCell.lifetimeRange = 3
+		
+		self.emitterCell.birthRate = 80
+		
+		self.emitterCell.velocity = 100
+		
+		self.emitterCell.emissionRange = CGFloat(M_PI) * 2.0
+		
+		self.emitterCell.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0).CGColor
+		
+		self.emitterCell.redRange = 1.0
+		self.emitterCell.blueRange = 1.0
+		self.emitterCell.greenRange = 1.0
+		self.emitterCell.alphaRange = 1.0
+	}
+}
+
+
+extension Layer {
+	
+	public func emitParticle(particle: Particle) {
+		let emitter = CAEmitterLayer()
+		emitter.birthRate = 1
+		emitter.emitterCells = [particle.emitterCell]
+		emitter.emitterMode = kCAEmitterLayerAdditive
+		
+		self.view.layer.addSublayer(emitter)
+		self.view.clipsToBounds = false
+	}
+}

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -117,7 +117,6 @@ extension Layer {
 		emitter.emitterCells = [particle.emitterCell]
 		emitter.renderMode = kCAEmitterLayerAdditive
 		emitter.bounds = self.view.layer.bounds
-		emitter.backgroundColor = UIColor.blackColor().CGColor
 		
 		self.view.layer.addSublayer(emitter)
 		self.view.clipsToBounds = false

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 
+/** Particles represent little pieces of some kind of animation, like confetti or rain drops or sparkles or flames, etc. */
 public struct Particle {
 	
 	let image: Image
@@ -176,7 +177,5 @@ public struct Particle {
 		get { return Double(self.emitterCell.zAcceleration) }
 		set { self.emitterCell.zAcceleration = CGFloat(newValue)}
 	}
-	
-	
 }
 

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -9,74 +9,15 @@
 import UIKit
 
 
-public enum ParticlePreset {
-	case Explode
-	case Rain
-	case Sparkle
-	
-	func configureParticle(var particle: Particle) {
-		switch self {
-		case Explode:
-			particle.lifetime = 3
-			particle.lifetimeRange = 3
-			
-			particle.birthRate = 80
-			
-			particle.velocity = 100
-			
-			particle.emissionRange = M_PI * 2.0
-			
-			particle.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
-			
-			particle.redRange = 1.0
-			particle.blueRange = 1.0
-			particle.greenRange = 1.0
-			particle.alphaRange = 1.0
-			
-		case Rain:
-			particle.lifetime = 4
-			particle.lifetimeRange = 5
-			particle.birthRate = 25
-			particle.velocity = 70
-			particle.velocityRange = 160
-			particle.yAcceleration = 1000
-			particle.emissionRange = Radian.circle
-			
-			particle.color = Color(red: 0, green: 0, blue: 1, alpha: 0.3)
-			particle.redRange = 0
-			particle.greenRange = 0
-			particle.blueRange = 1.0
-			particle.alphaRange = 0.55
-			
-			particle.scale = 0.4
-			
-		case Sparkle:
-			particle.lifetime = 0.71
-			particle.lifetimeRange = 0.5
-			particle.birthRate = 20
-			
-			particle.velocity = 6.5
-			particle.yAcceleration = -300
-			
-			particle.spin = Radian(degrees: -200)
-			particle.spinRange = Radian(degrees: 490)
-			
-			particle.color = Color(red: 1, green: 0.95, blue: 0.27, alpha: 0.65)
-			
-			particle.scale = 0.70
-			particle.scaleRange = 0.30
-		}
-	}
-}
-
 public struct Particle {
 	
 	let image: Image
 	let emitterCell: CAEmitterCell
 	
 	
-	public init(image: Image, preset: ParticlePreset) {
-		self.image = image
+	/** Create a new particle with the given image name and optional preset. */
+	public init(imageName: String, preset: ParticlePreset = .IKnowWhatImDoing) {
+		self.image = Image(name: imageName)
 		
 		self.emitterCell = CAEmitterCell()
 		self.emitterCell.contents = self.image.uiImage.CGImage

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -115,7 +115,9 @@ extension Layer {
 		let emitter = CAEmitterLayer()
 		emitter.birthRate = 1
 		emitter.emitterCells = [particle.emitterCell]
-//		emitter.emitterMode = kCAEmitterLayerAdditive
+		emitter.renderMode = kCAEmitterLayerAdditive
+		emitter.bounds = self.view.layer.bounds
+		emitter.backgroundColor = UIColor.blackColor().CGColor
 		
 		self.view.layer.addSublayer(emitter)
 		self.view.clipsToBounds = false

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -8,32 +8,63 @@
 
 import UIKit
 
+
+public enum ParticlePreset {
+	case Explode
+	case Rain
+	
+	func configureParticle(var particle: Particle) {
+		switch self {
+		case Explode:
+			particle.lifetime = 3
+			particle.lifetimeRange = 3
+			
+			particle.birthRate = 80
+			
+			particle.velocity = 100
+			
+			particle.emissionRange = M_PI * 2.0
+			
+			particle.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
+			
+			particle.redRange = 1.0
+			particle.blueRange = 1.0
+			particle.greenRange = 1.0
+			particle.alphaRange = 1.0
+			
+		case Rain:
+			particle.lifetime = 4
+			particle.lifetimeRange = 5
+			particle.birthRate = 25
+			particle.velocity = 70
+			particle.velocityRange = 160
+			particle.yAcceleration = 1000
+			particle.emissionRange = Radian.circle
+			
+			particle.color = Color(red: 0, green: 0, blue: 1, alpha: 0.3)
+			particle.redRange = 0
+			particle.greenRange = 0
+			particle.blueRange = 1.0
+			particle.alphaRange = 0.55
+			
+			particle.scale = 0.4
+		}
+	}
+}
+
 public struct Particle {
 	
 	let image: Image
 	private let emitterCell: CAEmitterCell
 	
-	public init(image: Image) {
+	
+	public init(image: Image, preset: ParticlePreset) {
 		self.image = image
 		
 		self.emitterCell = CAEmitterCell()
 		self.emitterCell.contents = self.image.uiImage.CGImage
 		
-		self.lifetime = 3
-		self.lifetimeRange = 3
-		
-		self.birthRate = 80
-		
-		self.velocity = 100
-		
-		self.emissionRange = M_PI * 2.0
-		
-		self.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
-		
-		self.redRange = 1.0
-		self.blueRange = 1.0
-		self.greenRange = 1.0
-		self.alphaRange = 1.0
+		preset.configureParticle(self)
 	}
 	
 	
@@ -60,10 +91,31 @@ public struct Particle {
 	}
 	
 	
+	/** The scale of the particles. */
+	public var scale: Double {
+		get { return Double(self.emitterCell.scale) }
+		set { self.emitterCell.scale = CGFloat(newValue) }
+	}
+	
+	
+	/** The range of particle scale. */
+	public var scaleRange: Double {
+		get { return Double(self.emitterCell.scaleRange) }
+		set { self.emitterCell.scaleRange = CGFloat(newValue) }
+	}
+	
+	
 	/** The velocity of particles. */
 	public var velocity: Double {
 		get { return Double(self.emitterCell.velocity) }
 		set { self.emitterCell.velocity = CGFloat(newValue) }
+	}
+	
+	
+	/** The velocity range of particles. */
+	public var velocityRange: Double {
+		get { return Double(self.emitterCell.velocityRange) }
+		set { self.emitterCell.velocityRange = CGFloat(newValue) }
 	}
 	
 	
@@ -106,6 +158,29 @@ public struct Particle {
 		get { return Double(self.emitterCell.alphaRange) }
 		set { self.emitterCell.alphaRange = Float(newValue) }
 	}
+	
+	
+	/** The x acceleration of particles. */
+	public var xAcceleration: Double {
+		get { return Double(self.emitterCell.xAcceleration) }
+		set { self.emitterCell.xAcceleration = CGFloat(newValue)}
+	}
+	
+	
+	/** The y acceleration of particles. */
+	public var yAcceleration: Double {
+		get { return Double(self.emitterCell.yAcceleration) }
+		set { self.emitterCell.yAcceleration = CGFloat(newValue)}
+	}
+	
+	
+	/** The z acceleration of particles. */
+	public var zAcceleration: Double {
+		get { return Double(self.emitterCell.zAcceleration) }
+		set { self.emitterCell.zAcceleration = CGFloat(newValue)}
+	}
+	
+	
 }
 
 
@@ -116,9 +191,13 @@ extension Layer {
 		emitter.birthRate = 1
 		emitter.emitterCells = [particle.emitterCell]
 		emitter.renderMode = kCAEmitterLayerAdditive
-		emitter.bounds = self.view.layer.bounds
-		
+		emitter.frame = self.view.layer.bounds
+		emitter.emitterShape = kCAEmitterLayerLine
+
 		self.view.layer.addSublayer(emitter)
 		self.view.clipsToBounds = false
+		
+		emitter.emitterPosition = emitter.position
+		emitter.emitterSize = emitter.bounds.size
 	}
 }

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -12,6 +12,7 @@ import UIKit
 public enum ParticlePreset {
 	case Explode
 	case Rain
+	case Sparkle
 	
 	func configureParticle(var particle: Particle) {
 		switch self {
@@ -48,6 +49,22 @@ public enum ParticlePreset {
 			particle.alphaRange = 0.55
 			
 			particle.scale = 0.4
+			
+		case Sparkle:
+			particle.lifetime = 0.71
+			particle.lifetimeRange = 0.5
+			particle.birthRate = 20
+			
+			particle.velocity = 6.5
+			particle.yAcceleration = -300
+			
+			particle.spin = Radian(degrees: -200)
+			particle.spinRange = Radian(degrees: 490)
+			
+			particle.color = Color(red: 1, green: 0.95, blue: 0.27, alpha: 0.65)
+			
+			particle.scale = 0.70
+			particle.scaleRange = 0.30
 		}
 	}
 }
@@ -102,6 +119,20 @@ public struct Particle {
 	public var scaleRange: Double {
 		get { return Double(self.emitterCell.scaleRange) }
 		set { self.emitterCell.scaleRange = CGFloat(newValue) }
+	}
+	
+	
+	/** The spin of particles. Positive values spin clockwise, negative values spin counter-clockwise. */
+	public var spin: Radian {
+		get { return Radian(self.emitterCell.spin) }
+		set { self.emitterCell.spin = CGFloat(newValue) }
+	}
+	
+	
+	/** The spin range of particles. Positive values spin clockwise, negative values spin counter-clockwise. */
+	public var spinRange: Radian {
+		get { return Radian(self.emitterCell.spinRange) }
+		set { self.emitterCell.spinRange = CGFloat(newValue) }
 	}
 	
 	

--- a/Prototope/Particle.swift
+++ b/Prototope/Particle.swift
@@ -132,6 +132,31 @@ public struct Particle {
 	}
 	
 	
+	/** The speed of red in the particle. */
+	public var redSpeed: Double {
+		get { return Double(self.emitterCell.redSpeed) }
+		set { self.emitterCell.redSpeed = Float(newValue) }
+	}
+	
+	/** The speed of blue in the particle. */
+	public var blueSpeed: Double {
+		get { return Double(self.emitterCell.blueSpeed) }
+		set { self.emitterCell.blueSpeed = Float(newValue) }
+	}
+	
+	/** The speed of green in the particle. */
+	public var greenSpeed: Double {
+		get { return Double(self.emitterCell.greenSpeed) }
+		set { self.emitterCell.greenSpeed = Float(newValue) }
+	}
+	
+	/** The speed of alpha in the particle. */
+	public var alphaSpeed: Double {
+		get { return Double(self.emitterCell.alphaSpeed) }
+		set { self.emitterCell.alphaSpeed = Float(newValue) }
+	}
+	
+	
 	/** The x acceleration of particles. */
 	public var xAcceleration: Double {
 		get { return Double(self.emitterCell.xAcceleration) }

--- a/Prototope/ParticleEmitter.swift
+++ b/Prototope/ParticleEmitter.swift
@@ -21,6 +21,10 @@ public class ParticleEmitter {
 		}
 	}
 	
+	public var birthRate: Double {
+		get { return Double(self.emitterLayer.birthRate) }
+		set { self.emitterLayer.birthRate = Float(newValue) }
+	}
 	
 	/** The render mode of the emitter. */
 	public var renderMode: String {

--- a/Prototope/ParticleEmitter.swift
+++ b/Prototope/ParticleEmitter.swift
@@ -1,0 +1,81 @@
+//
+//  ParticleEmitter.swift
+//  Prototope
+//
+//  Created by Jason Brennan on Feb-05-2015.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+public class ParticleEmitter {
+	let particles: [Particle]
+	
+	let emitterLayer = CAEmitterLayer()
+	
+	public init(particles: [Particle]) {
+		self.particles = particles
+		self.emitterLayer.emitterCells = self.particles.map {
+			(particle: Particle) -> AnyObject in
+			return particle.emitterCell
+		}
+	}
+	
+	
+	/** The render mode of the emitter. */
+	public var renderMode: String {
+		get { return self.emitterLayer.renderMode }
+		set { self.emitterLayer.renderMode = newValue }
+	}
+	
+	
+	/** The shape of the emitter. c.f., CAEmitterLayer for valid strings. */
+	public var emitterShape: String {
+		get { return self.emitterLayer.emitterShape }
+		set { self.emitterLayer.emitterShape = newValue }
+	}
+	
+	
+	/** The render mode of the emitter. */
+	public var size: Size {
+		get { return Size(self.emitterLayer.emitterSize) }
+		set { self.emitterLayer.emitterSize = CGSize(newValue) }
+	}
+	
+	
+	/** The render mode of the emitter. */
+	public var position: Point {
+		get { return Point(self.emitterLayer.emitterPosition) }
+		set { self.emitterLayer.emitterPosition = CGPoint(newValue) }
+	}
+
+	public var x: Double {
+		get { return self.position.x }
+		set { self.position = Point(x: newValue, y: self.y) }
+	}
+	
+	
+	public var y: Double {
+		get { return self.position.y }
+		set { self.position = Point(x: self.x, y: newValue) }
+	}
+}
+
+
+//extension Layer {
+//	
+//	public func emitParticle(particle: Particle) {
+//		let emitter = CAEmitterLayer()
+//		
+//		emitter.emitterCells = [particle.emitterCell]
+//		emitter.renderMode = kCAEmitterLayerAdditive
+//		emitter.frame = self.view.layer.bounds
+//		emitter.emitterShape = kCAEmitterLayerLine
+//		
+//		self.view.layer.addSublayer(emitter)
+//		self.view.clipsToBounds = false
+//		
+//		emitter.emitterPosition = emitter.position
+//		emitter.emitterSize = emitter.bounds.size
+//	}
+//}

--- a/Prototope/ParticleEmitter.swift
+++ b/Prototope/ParticleEmitter.swift
@@ -8,11 +8,13 @@
 
 import Foundation
 
+/** A particle emitter shows one or more kinds of Particles, and can show them in different formations. */
 public class ParticleEmitter {
 	let particles: [Particle]
 	
 	let emitterLayer = CAEmitterLayer()
 	
+	/** Creates a particle emitter with an array of particles. */
 	public init(particles: [Particle]) {
 		self.particles = particles
 		self.emitterLayer.emitterCells = self.particles.map {
@@ -21,6 +23,14 @@ public class ParticleEmitter {
 		}
 	}
 	
+	
+	/** Creates a particle emitter with one kind of particle. */
+	public convenience init(particle: Particle) {
+		self.init(particles: [particle])
+	}
+	
+	
+	/** How often new baby particles are born. */
 	public var birthRate: Double {
 		get { return Double(self.emitterLayer.birthRate) }
 		set { self.emitterLayer.birthRate = Float(newValue) }
@@ -52,34 +62,18 @@ public class ParticleEmitter {
 		get { return Point(self.emitterLayer.emitterPosition) }
 		set { self.emitterLayer.emitterPosition = CGPoint(newValue) }
 	}
-
+	
+	
+	/** The x position of the emitter. This is a shortcut for `position`. */
 	public var x: Double {
 		get { return self.position.x }
 		set { self.position = Point(x: newValue, y: self.y) }
 	}
 	
 	
+	/** The y position of the emitter. This is a shortcut for `position`. */
 	public var y: Double {
 		get { return self.position.y }
 		set { self.position = Point(x: self.x, y: newValue) }
 	}
 }
-
-
-//extension Layer {
-//	
-//	public func emitParticle(particle: Particle) {
-//		let emitter = CAEmitterLayer()
-//		
-//		emitter.emitterCells = [particle.emitterCell]
-//		emitter.renderMode = kCAEmitterLayerAdditive
-//		emitter.frame = self.view.layer.bounds
-//		emitter.emitterShape = kCAEmitterLayerLine
-//		
-//		self.view.layer.addSublayer(emitter)
-//		self.view.clipsToBounds = false
-//		
-//		emitter.emitterPosition = emitter.position
-//		emitter.emitterSize = emitter.bounds.size
-//	}
-//}

--- a/Prototope/ParticleEmitter.swift
+++ b/Prototope/ParticleEmitter.swift
@@ -30,7 +30,7 @@ public class ParticleEmitter {
 	
 	
 	/** The shape of the emitter. c.f., CAEmitterLayer for valid strings. */
-	public var emitterShape: String {
+	public var shape: String {
 		get { return self.emitterLayer.emitterShape }
 		set { self.emitterLayer.emitterShape = newValue }
 	}

--- a/Prototope/ParticlePreset.swift
+++ b/Prototope/ParticlePreset.swift
@@ -27,7 +27,7 @@ public enum ParticlePreset {
 	/** Sets nothing on the particle. We trust you to do the right thing. */
 	case IKnowWhatImDoing
 	
-	func configureParticle(var particle: Particle) {
+	internal func configureParticle(var particle: Particle) {
 		switch self {
 		case Explode:
 			particle.lifetime = 3

--- a/Prototope/ParticlePreset.swift
+++ b/Prototope/ParticlePreset.swift
@@ -1,0 +1,86 @@
+//
+//  ParticlePreset.swift
+//  Prototope
+//
+//  Created by Jason Brennan on Feb-06-2015.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+
+/** These are presets you can use when setting up a particle. 
+	
+	Use these as starting points for configuring your particles, 
+	or use .IKnowWhatImDoing and configure everything yourself. */
+public enum ParticlePreset {
+	
+	/** Particles explode in all directions. */
+	case Explode
+	
+	/** Particles fall like rain all the way down. */
+	case Rain
+	
+	/** Particles fly upward and and quickly burn out. */
+	case Sparkle
+	
+	/** Sets nothing on the particle. We trust you to do the right thing. */
+	case IKnowWhatImDoing
+	
+	func configureParticle(var particle: Particle) {
+		switch self {
+		case Explode:
+			particle.lifetime = 3
+			particle.lifetimeRange = 3
+			
+			particle.birthRate = 80
+			
+			particle.velocity = 100
+			
+			particle.emissionRange = M_PI * 2.0
+			
+			particle.color = Color(red: 0.5, green: 0.5, blue: 0.5, alpha: 1.0)
+			
+			particle.redRange = 1.0
+			particle.blueRange = 1.0
+			particle.greenRange = 1.0
+			particle.alphaRange = 1.0
+			
+		case Rain:
+			particle.lifetime = 4
+			particle.lifetimeRange = 5
+			particle.birthRate = 25
+			particle.velocity = 70
+			particle.velocityRange = 160
+			particle.yAcceleration = 1000
+			particle.emissionRange = Radian.circle
+			
+			particle.color = Color(red: 0, green: 0, blue: 1, alpha: 0.3)
+			particle.redRange = 0
+			particle.greenRange = 0
+			particle.blueRange = 1.0
+			particle.alphaRange = 0.55
+			
+			particle.scale = 0.4
+			
+		case Sparkle:
+			particle.lifetime = 0.71
+			particle.lifetimeRange = 0.5
+			particle.birthRate = 20
+			
+			particle.velocity = 6.5
+			particle.yAcceleration = -300
+			
+			particle.spin = Radian(degrees: -200)
+			particle.spinRange = Radian(degrees: 490)
+			
+			particle.color = Color(red: 1, green: 0.95, blue: 0.27, alpha: 0.65)
+			
+			particle.scale = 0.70
+			particle.scaleRange = 0.30
+			
+		case IKnowWhatImDoing:
+			break
+		}
+	}
+}

--- a/Prototope/ParticlePreset.swift
+++ b/Prototope/ParticlePreset.swift
@@ -74,7 +74,8 @@ public enum ParticlePreset {
 			particle.spin = Radian(degrees: -200)
 			particle.spinRange = Radian(degrees: 490)
 			
-			particle.color = Color(red: 1, green: 0.95, blue: 0.27, alpha: 0.65)
+			particle.color = Color(red: 1, green: 0.95, blue: 0.27, alpha: 0)
+			particle.alphaSpeed = 3
 			
 			particle.scale = 0.70
 			particle.scaleRange = 0.30

--- a/Prototope/Radian.swift
+++ b/Prototope/Radian.swift
@@ -15,4 +15,10 @@ extension Radian {
 	
 	/** One full revolution in radians. */
 	static let circle = 2.0 * M_PI
+	
+	
+	/** Initialize a radian with degrees. */
+	public init(degrees: Double) {
+		self.init(degrees * M_PI / 180)
+	}
 }

--- a/Prototope/Radian.swift
+++ b/Prototope/Radian.swift
@@ -1,0 +1,12 @@
+//
+//  Radian.swift
+//  Prototope
+//
+//  Created by Jason Brennan on Feb-05-2015.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import Foundation
+
+/** For when we're dealing with radians, this type makes it more explicit. */
+public typealias Radian = Double

--- a/Prototope/Radian.swift
+++ b/Prototope/Radian.swift
@@ -10,3 +10,9 @@ import Foundation
 
 /** For when we're dealing with radians, this type makes it more explicit. */
 public typealias Radian = Double
+
+extension Radian {
+	
+	/** One full revolution in radians. */
+	static let circle = 2.0 * M_PI
+}


### PR DESCRIPTION

![tumblr_inline_mk6dndpcx91qz4rgp](https://cloud.githubusercontent.com/assets/131923/6086364/f9254648-ae0e-11e4-9e89-83466aad50ce.gif)


What it does
----------------

- Adds a wrapper around `CAEmitterCell` and `CAEmitterLayer` to provide layer-based particles.
- Adds presets for certain kinds of particles, because there’s a dizzying array of settings and it’s hard to know what’s going to look good.
- Adds a `Radian` type to make it more explicit when we’re dealing in radians. `Radian` is just a type alias for `Double`, but more semantically sound.

 