### PR TITLE
[FIN] Make `AnimationDelegate` available to pop

### DIFF
--- a/Prototope/Animation.swift
+++ b/Prototope/Animation.swift
@@ -212,10 +212,10 @@ extension Layer {
 
 // MARK: - Internal interfaces
 
-@objc private class AnimationDelegate: NSObject, POPAnimationDelegate {
+@objc public class AnimationDelegate: NSObject, POPAnimationDelegate {
 	var completionHandler: (() -> Void)?
 
-	func pop_animationDidStop(animation: POPAnimation, finished: Bool) {
+	public func pop_animationDidStop(animation: POPAnimation, finished: Bool) {
 		completionHandler?()
 	}
 }

--- a/Prototope/Animation.swift
+++ b/Prototope/Animation.swift
@@ -212,10 +212,10 @@ extension Layer {
 
 // MARK: - Internal interfaces
 
-@objc public class AnimationDelegate: NSObject, POPAnimationDelegate {
+private class AnimationDelegate: NSObject, POPAnimationDelegate {
 	var completionHandler: (() -> Void)?
 
-	public func pop_animationDidStop(animation: POPAnimation, finished: Bool) {
+	@objc func pop_animationDidStop(animation: POPAnimation, finished: Bool) {
 		completionHandler?()
 	}
 }


### PR DESCRIPTION
pop_animationDidStop was never called by the pop framework