### PR TITLE
[FIN] TextLayer – Baseline Enhancements

### DIFF
--- a/Examples/TestText/main.js
+++ b/Examples/TestText/main.js
@@ -20,6 +20,14 @@ wrappingLayer.x = Layer.root.x
 wrappingLayer.y = 300
 wrappingLayer.width = 100
 
+var alignmentLayer = new TextLayer()
+alignmentLayer.text = "align"
+alignmentLayer.fontSize = 64
+alignmentLayer.border = new Border({color: Color.red, width: 1})
+
 var h = new Heartbeat({handler: function(heartbeat) {
 	wrappingLayer.width = 100 + Math.sin(heartbeat.timestamp * 4) * 50
+	alignmentLayer.alignWithBaselineOf(wrappingLayer)
+	alignmentLayer.x = wrappingLayer.x + wrappingLayer.width*0.5 + alignmentLayer.width*0.5
+
 }})

--- a/Prototope/Math.swift
+++ b/Prototope/Math.swift
@@ -33,3 +33,15 @@ public func map(value: Double, #fromInterval: (Double, Double), #toInterval: (Do
 public func clip<T: Comparable>(value: T, min minValue: T, max maxValue: T) -> T {
 	return max(min(value, maxValue), minValue)
 }
+
+/** `ceil`s the value, snapping to screen's pixel values */
+public func pixelAwareCeil(value: Double) -> Double {
+	let scale = Double(UIScreen.mainScreen().scale)
+	return ceil(value*scale)/scale
+}
+
+/** `floor`s the value, snapping to screen's pixel values */
+public func pixelAwareFloor(value: Double) -> Double {
+	let scale = Double(UIScreen.mainScreen().scale)
+	return floor(value*scale)/scale
+}

--- a/Prototope/TextLayer.swift
+++ b/Prototope/TextLayer.swift
@@ -111,7 +111,7 @@ public class TextLayer: Layer {
 		return Double(label.font.ascender)
 	}
 	
-	/** Aligns this layer with the first baseline of the other layer */
+	/** Aligns this layer's first baseline with the first baseline of the other layer */
 	public func alignWithBaselineOf(otherLayer: TextLayer) {
 		var delta = pixelAwareCeil(otherLayer.baselineHeight-baselineHeight)
 		

--- a/Prototope/TextLayer.swift
+++ b/Prototope/TextLayer.swift
@@ -105,7 +105,21 @@ public class TextLayer: Layer {
 			//No need to adjust size, since changing alignment doesn't influence it
 		}
 	}
-
+	
+	/** Distance from top of layer to the first line's baseline */
+	public var baselineHeight: Double {
+		return Double(label.font.ascender)
+	}
+	
+	/** Aligns this layer with the first baseline of the other layer */
+	public func alignWithBaselineOf(otherLayer: TextLayer) {
+		var delta = pixelAwareCeil(otherLayer.baselineHeight-baselineHeight)
+		
+		var frame = self.frame
+		frame.origin.y = otherLayer.frame.minY + delta
+		self.frame = frame
+	}
+	
 	public override var frame: Rect {
 		didSet {
 			// Respect the new width; resize height so as not to truncate.

--- a/Prototope/TextLayer.swift
+++ b/Prototope/TextLayer.swift
@@ -113,11 +113,9 @@ public class TextLayer: Layer {
 	
 	/** Aligns this layer's first baseline with the first baseline of the other layer */
 	public func alignWithBaselineOf(otherLayer: TextLayer) {
-		var delta = pixelAwareCeil(otherLayer.baselineHeight-baselineHeight)
+		let delta = pixelAwareCeil(otherLayer.baselineHeight-baselineHeight)
 		
-		var frame = self.frame
-		frame.origin.y = otherLayer.frame.minY + delta
-		self.frame = frame
+		self.frame.origin.y = otherLayer.frame.minY + delta
 	}
 	
 	public override var frame: Rect {

--- a/PrototopeJSBridge/MathBridge.swift
+++ b/PrototopeJSBridge/MathBridge.swift
@@ -40,5 +40,19 @@ public struct MathBridge: BridgeType {
 			)
 		}
 		context.setFunctionForKey("clip", fn: clipTrampoline)
+		
+		let pixelAwareCeil: @objc_block NSDictionary -> Double = { args in
+			Prototope.pixelAwareCeil(
+				(args["value"] as! Double?) ?? 0
+			)
+		}
+		context.setFunctionForKey("pixelAwareCeil", fn: pixelAwareCeil)
+		
+		let pixelAwareFloor: @objc_block NSDictionary -> Double = { args in
+			Prototope.pixelAwareFloor(
+				(args["value"] as! Double?) ?? 0
+			)
+		}
+		context.setFunctionForKey("pixelAwareFloor", fn: pixelAwareCeil)
 	}
 }

--- a/PrototopeJSBridge/TextLayerBridge.swift
+++ b/PrototopeJSBridge/TextLayerBridge.swift
@@ -17,8 +17,9 @@ import JavaScriptCore
 	var textColor: ColorJSExport { get set }
 	var wraps: Bool { get set }
 	var textAlignment: JSValue { get set }
+	var baselineHeight: Double { get }
+	func alignWithBaselineOf(layer: TextLayerJSExport)
 }
-
 
 @objc public class TextLayerBridge: LayerBridge, TextLayerJSExport, BridgeType {
 	var textLayer: TextLayer { return layer as! TextLayer }
@@ -62,6 +63,14 @@ import JavaScriptCore
 	public var textAlignment: JSValue {
 		get { return TextAlignmentBridge.encodeAlignment(textLayer.textAlignment, inContext: JSContext.currentContext()) }
 		set { textLayer.textAlignment = TextAlignmentBridge.decodeAlignment(newValue) }
+	}
+	
+	public var baselineHeight: Double {
+		return textLayer.baselineHeight
+	}
+	
+	public func alignWithBaselineOf(otherLayer: TextLayerJSExport) {
+		textLayer.alignWithBaselineOf((otherLayer as JSExport as! TextLayerBridge).textLayer)
 	}
 }
 


### PR DESCRIPTION
Depends on https://github.com/Khan/Prototope/pull/23 (Well, doesn’t actually depend, but contains commits from that – all the unrelated TextAlignment stuff).

* getter for the offset from the top of a `TextLayer` to its first line’s baseline.
* convenience function to align a `TextLayer` to another `TextLayer`’s first line’s baseline.
* device-pixel-aware `ceil` and `floor` functions