### PR TITLE
[FIN] Smarter scene URL selection

### DIFF
--- a/Protocaster/AppDelegate.swift
+++ b/Protocaster/AppDelegate.swift
@@ -32,9 +32,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, DTBonjourDataConnectionDeleg
 			}
 		}
 	}
+    
+    private final func sceneURL(fromURL URL: NSURL) -> NSURL? {
+        var isDirectoryValue: AnyObject?
+        URL.getResourceValue(&isDirectoryValue, forKey: NSURLIsDirectoryKey, error: nil)
+        
+        let isDirectory = (isDirectoryValue as? NSNumber)?.boolValue ?? false
+        
+        if !isDirectory {
+            return URL.URLByDeletingLastPathComponent
+        }
+        
+        return URL
+    }
 
 	private func selectedPathDidChange(newURL: NSURL?) {
-		if let URL = newURL {
+		if let URL = (newURL >>- sceneURL) {
 			if .Some(URL) != monitor?.URL {
 				monitor = URLMonitor(URL: URL)
 				monitor!.everythingDidChangeHandler = {

--- a/Protocaster/AppDelegate.swift
+++ b/Protocaster/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, DTBonjourDataConnectionDeleg
     }
 
 	private func selectedPathDidChange(newURL: NSURL?) {
-		if let URL = (newURL >>- sceneURL) {
+        if let URL = newURL, let sceneURL = sceneURL(fromURL: URL) {
 			if .Some(URL) != monitor?.URL {
 				monitor = URLMonitor(URL: URL)
 				monitor!.everythingDidChangeHandler = {


### PR DESCRIPTION
If a file is selected, then the containing directory will be treated as selected. This should prevent situations where a user will accidentally select a main.js file instead of the directory which contains the rest of the scene's resources.