### PR TITLE
JS prototypes use JS strict mode

### DIFF
--- a/Examples/Color Puddles/main.js
+++ b/Examples/Color Puddles/main.js
@@ -39,7 +39,7 @@ touchLayer.touchEndedHandler = touchLayer.touchCancelledHandler = function(touch
 }
 
 var h = new Heartbeat({handler: function() {
-	for (layer in touchLayers) {
+	for (var layer in touchLayers) {
 		touchLayers[layer].scale *= 1.11
 	}
 }})

--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		EBA049B11A8AFC87008BC4AD /* ExceptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA049B01A8AFC87008BC4AD /* ExceptionView.swift */; };
 		EBA049C01A8BCB32008BC4AD /* ConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA049BF1A8BCB32008BC4AD /* ConsoleView.swift */; };
 		EBA049C21A8BCCB0008BC4AD /* ExceptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA049C11A8BCCB0008BC4AD /* ExceptionViewController.swift */; };
+		EBA0DB2E1AA5426E00A030A0 /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA0DB2D1AA5426E00A030A0 /* ContextTests.swift */; };
 		EBA837171A1DADDF00D23C9D /* Heartbeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA837161A1DADDF00D23C9D /* Heartbeat.swift */; };
 		EBA8371C1A1DB51000D23C9D /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBA8371B1A1DB51000D23C9D /* Sound.swift */; };
 		EBA8371E1A1DB6E300D23C9D /* Glass.aiff in Resources */ = {isa = PBXBuildFile; fileRef = EBA8371D1A1DB6E300D23C9D /* Glass.aiff */; };
@@ -488,6 +489,7 @@
 		EBA049B01A8AFC87008BC4AD /* ExceptionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExceptionView.swift; sourceTree = "<group>"; };
 		EBA049BF1A8BCB32008BC4AD /* ConsoleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConsoleView.swift; sourceTree = "<group>"; };
 		EBA049C11A8BCCB0008BC4AD /* ExceptionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExceptionViewController.swift; sourceTree = "<group>"; };
+		EBA0DB2D1AA5426E00A030A0 /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 		EBA837161A1DADDF00D23C9D /* Heartbeat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Heartbeat.swift; sourceTree = "<group>"; };
 		EBA8371B1A1DB51000D23C9D /* Sound.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sound.swift; sourceTree = "<group>"; };
 		EBA8371D1A1DB6E300D23C9D /* Glass.aiff */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = Glass.aiff; sourceTree = "<group>"; };
@@ -825,6 +827,7 @@
 				EBC43D811A81B7040075272A /* MathBridgeTests.swift */,
 				EBC43D851A81BBC30075272A /* HeartbeatBridgeTests.swift */,
 				EB2A88581A83008000E3987F /* GestureBridgeTests.swift */,
+				EBA0DB2D1AA5426E00A030A0 /* ContextTests.swift */,
 				EB453DA01A7AB0B2006F2A72 /* Supporting Files */,
 			);
 			name = Tests;
@@ -1545,6 +1548,7 @@
 				EBC43D7A1A81AC020075272A /* TunableBridgeTests.swift in Sources */,
 				EB2A88591A83008000E3987F /* GestureBridgeTests.swift in Sources */,
 				EBC43D7E1A81B0FB0075272A /* TimingBridgeTests.swift in Sources */,
+				EBA0DB2E1AA5426E00A030A0 /* ContextTests.swift in Sources */,
 				EBC43D741A81959B0075272A /* JSBridgeTestCase.swift in Sources */,
 				EBC43D821A81B7040075272A /* MathBridgeTests.swift in Sources */,
 			);

--- a/PrototopeJSBridge/Context.swift
+++ b/PrototopeJSBridge/Context.swift
@@ -31,7 +31,7 @@ public class Context {
 	}
 
 	public func evaluateScript(script: String!) -> JSValue {
-		return context.evaluateScript(script)
+		return context.evaluateScript("\"use strict\";" + script)
 	}
 
 	private func addBridgedTypes() {

--- a/PrototopeJSBridgeTests/ContextTests.swift
+++ b/PrototopeJSBridgeTests/ContextTests.swift
@@ -1,0 +1,21 @@
+//
+//  ContextBridgeTests.swift
+//  Prototope
+//
+//  Created by Andy Matuschak on 3/2/15.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import Foundation
+import PrototopeJSBridge
+import XCTest
+
+class ContextTests: JSBridgeTestCase {
+	func testContextExecutesInStrictMode() {
+		let context = Context()
+		var hitException = false
+		context.exceptionHandler = { _ in hitException = true }
+		context.evaluateScript("x = 4")
+		XCTAssertTrue(hitException)
+	}
+}


### PR DESCRIPTION
Tested all our JS prototypes to make sure they still function as expected. Fixed one; the rest look good.

This will make us throw protonopes for common errors (e.g. referring to variables that don't exist).