### PR TITLE
The root layer is now *hosted* by a root view, but does not wrap that view.

### DIFF
--- a/Prototope/Environment.swift
+++ b/Prototope/Environment.swift
@@ -18,7 +18,7 @@ public struct Environment {
 	public static var currentEnvironment: Environment?
 
 	public init(rootView: UIView, imageProvider: String -> UIImage?, soundProvider: String -> NSData?) {
-		self.rootLayer = Layer(wrappingView: rootView, name: "Root")
+		self.rootLayer = Layer(hostingView: rootView, name: "Root")
 
 		// TODO: move defaultSpec into Environment.
 		let gesture = defaultSpec.twoFingerTripleTapGestureRecognizer()

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -594,10 +594,19 @@ public class Layer: Equatable, Hashable {
 		}
 	}
 
-	init(wrappingView: UIView, name: String? = nil) {
+	private init(wrappingView: UIView, name: String? = nil) {
 		view = wrappingView
 		self.name = name
 	}
+    
+    
+	/** Creates a new layer hosted by the given view. The layer wraps its own view, which is sized to the full dimensions of the hosting view. */
+    convenience init(hostingView: UIView, name: String? = nil) {
+        self.init()
+        self.parentView = hostingView
+		self.frame = Rect(hostingView.bounds)
+		self.view.autoresizingMask = .FlexibleWidth | .FlexibleHeight
+    }
 
 	// MARK: UIKit mapping
 


### PR DESCRIPTION
This is done so that the root layer in the layer tree works exactly like every other node in the tree. It is no longer special (i.e., broken) because its view is no longer at the top of the view hierarchy.

[Fixes #37]