### PR TITLE
Upgrading Prototope to Xcode 8.3b3's Swift (breaks earlier builds)

### DIFF
--- a/Protoscope/ConsoleView.swift
+++ b/Protoscope/ConsoleView.swift
@@ -40,7 +40,7 @@ class ConsoleView: UIView {
 		textView.textStorage.deleteCharactersInRange(NSMakeRange(0, textView.textStorage.length))
 	}
 
-	override init() {
+	init() {
 		let blurEffect = UIBlurEffect(style: .Dark)
 		visualEffectView = UIVisualEffectView(effect: blurEffect)
 		visualEffectView.autoresizingMask = .FlexibleWidth | .FlexibleHeight

--- a/Protoscope/ExceptionView.swift
+++ b/Protoscope/ExceptionView.swift
@@ -34,7 +34,7 @@ class ExceptionView: UIView {
 		return textView
 	}()
 
-	override init() {
+	init() {
 		super.init(frame: CGRect())
 		backgroundColor = Style.warning
 

--- a/Protoscope/ExceptionViewController.swift
+++ b/Protoscope/ExceptionViewController.swift
@@ -16,7 +16,7 @@ class ExceptionViewController: UIViewController {
 
 	private var exceptionView: ExceptionView { return view as! ExceptionView }
 
-	override init() {
+	init() {
 		super.init(nibName: nil, bundle: nil)
 	}
 

--- a/Protoscope/RootViewController.swift
+++ b/Protoscope/RootViewController.swift
@@ -20,7 +20,7 @@ class RootViewController: UIViewController {
 	var protoscopeNavigationController: UINavigationController!
 	var statusViewController: UIViewController!
 
-	override init() {
+	init() {
 		super.init(nibName: nil, bundle: nil)
 	}
 

--- a/Protoscope/SceneViewController.swift
+++ b/Protoscope/SceneViewController.swift
@@ -72,7 +72,7 @@ class SceneViewController: UIViewController {
 		}
 	}
 
-	override init() {
+	init() {
 		super.init(nibName: nil, bundle: nil)
 	}
 

--- a/Protoscope/StatusView.swift
+++ b/Protoscope/StatusView.swift
@@ -30,7 +30,7 @@ class StatusView: UIView {
 			}, completion: nil)
 	}
 
-	override init() {
+	init() {
 		super.init(frame: CGRect())
 		backgroundColor = Style.cyan
 		addSubview(prototopeP)

--- a/Protoscope/StatusViewController.swift
+++ b/Protoscope/StatusViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class StatusViewController: UIViewController {
-	override init() {
+	init() {
 		super.init(nibName: nil, bundle: nil)
 	}
 

--- a/Prototope/Animation.swift
+++ b/Prototope/Animation.swift
@@ -161,7 +161,7 @@ public class Animator<Target: AnimatorValueConvertible> {
 		return (self.shouldAnimateLayer ? layer?.view.layer : layer?.view)
 	}
 
-	/** On a brighter note, with beta 3, our app now compiles -O for the first time ever! Hooray and congrats. */
+	/** Immediately stops the animation. */
 	public func stop() {
 		animatable()?.pop_removeAnimationForKey(property.name)
 	}

--- a/Prototope/Animation.swift
+++ b/Prototope/Animation.swift
@@ -161,7 +161,7 @@ public class Animator<Target: AnimatorValueConvertible> {
 		return (self.shouldAnimateLayer ? layer?.view.layer : layer?.view)
 	}
 
-	/** Immediately stops the animation. */
+	/** On a brighter note, with beta 3, our app now compiles -O for the first time ever! Hooray and congrats. */
 	public func stop() {
 		animatable()?.pop_removeAnimationForKey(property.name)
 	}

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -637,7 +637,7 @@ public class Layer: Equatable, Hashable {
 			super.init(frame: frame)
 		}
 
-		override convenience init() {
+		convenience init() {
 			self.init(frame: CGRect())
 		}
 


### PR DESCRIPTION
The inscrutable `override` vs. `convenience` vs. whatever rules appear to have changed again.