### PR TITLE
JS bridge for ShapeLayer

### DIFF
--- a/Examples/ShapeLayer/ShapeLayer.js
+++ b/Examples/ShapeLayer/ShapeLayer.js
@@ -1,0 +1,81 @@
+// You can draw by tapping:
+
+var hintLabel = new TextLayer()
+hintLabel.text = "Tap to draw!"
+hintLabel.fontSize = 40
+hintLabel.x = Layer.root.x
+hintLabel.originY = 30
+
+var drawing = new ShapeLayer()
+drawing.strokeWidth = 2
+drawing.fillColor = new Color({hue: 0.1, saturation: 0.3, brightness: 1.0})
+drawing.lineCapStyle = LineCapStyle.Round
+drawing.closed = true
+drawing.lineJoinStyle = LineJoinStyle.Round
+
+var currentPointDot = new ShapeLayer.Circle({center: Point.zero, radius: 10})
+currentPointDot.alpha = 0
+
+Layer.root.touchBeganHandler = function(sequence) {
+	currentPointDot.alpha = 1
+	currentPointDot.position = sequence.currentSample.globalLocation
+	drawing.addPoint(sequence.currentSample.globalLocation)
+}
+
+Layer.root.touchMovedHandler = function(sequence) {
+	var segments = drawing.segments
+	var lastSegment = segments.pop()
+	lastSegment.point = sequence.currentSample.globalLocation
+	segments.push(lastSegment)
+	drawing.segments = segments
+
+	currentPointDot.position = sequence.currentSample.globalLocation
+}
+
+Layer.root.touchEndedHandler = Layer.root.touchCancelledHandler = function(sequence) {
+	currentPointDot.alpha = 0
+}
+
+// Demo of various shapes.
+
+var circle = new ShapeLayer.Circle({
+	center: new Point({x: 75, y: Layer.root.frameMaxY - 75}),
+	radius: 50
+})
+circle.fillColor = new Color({hue: 0.3, saturation: 0.6, brightness: 1.0})
+circle.strokeColor = undefined
+
+var oval = new ShapeLayer.Oval({
+	rectangle: new Rect({x: circle.frameMaxX + 25, y: circle.originY, width: 50, height: circle.height})
+})
+oval.fillColor = undefined
+oval.strokeColor = new Color({hue: 0.6, saturation: 0.6, brightness: 1.0})
+oval.strokeWidth = 4
+
+var polygon = new ShapeLayer.Polygon({center: Point.zero, radius: 50, numberOfSides: 5})
+polygon.strokeWidth = 4
+polygon.fillColor = new Color({hue: 0.8, saturation: 0.6, brightness: 1.0})
+polygon.strokeColor = undefined
+polygon.lineCapStyle = LineCapStyle.Round
+polygon.lineJoinStyle = LineJoinStyle.Round
+polygon.y = oval.y
+polygon.originX = oval.frameMaxX + 25
+
+var pizza = new ShapeLayer()
+pizza.fillColor = Color.orange
+pizza.strokeColor = undefined
+pizza.segments = [
+	new Segment({
+		point: new Point({x: 10, y: 10}),
+		handleIn: new Point({x: -10, y: 10}),
+		handleOut: new Point({x: 10, y: -10})
+	}),
+	new Segment({
+		point: new Point({x: 100, y: 30}),
+		handleIn: new Point({x: -10, y: -10}),
+		handleOut: new Point({x: -10, y: 10})
+	}),
+	new Segment(new Point({x: 30, y: 100})),
+]
+pizza.originX = polygon.frameMaxX + 25
+pizza.y = polygon.y

--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6175CE291A7F1B01001E63CE /* BridgeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175CE281A7F1B01001E63CE /* BridgeType.swift */; };
 		6175CE2B1A7F1B71001E63CE /* ColorBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175CE2A1A7F1B71001E63CE /* ColorBridge.swift */; };
+		61A1BA451ACF51A600780650 /* ShapeLayerBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A1BA441ACF51A600780650 /* ShapeLayerBridge.swift */; };
 		752064901A89E3A0005E38A2 /* Behaviors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7520648F1A89E39F005E38A2 /* Behaviors.swift */; };
 		753E20E81A84A12100E30460 /* JSTest.js in Resources */ = {isa = PBXBuildFile; fileRef = 753E20E71A84A12100E30460 /* JSTest.js */; };
 		7541D6331AA97708009374FB /* ExceptionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7541D6231AA97528009374FB /* ExceptionHandlingTests.swift */; };
@@ -411,6 +412,7 @@
 /* Begin PBXFileReference section */
 		6175CE281A7F1B01001E63CE /* BridgeType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BridgeType.swift; sourceTree = "<group>"; };
 		6175CE2A1A7F1B71001E63CE /* ColorBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorBridge.swift; sourceTree = "<group>"; };
+		61A1BA441ACF51A600780650 /* ShapeLayerBridge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShapeLayerBridge.swift; sourceTree = "<group>"; };
 		7520648F1A89E39F005E38A2 /* Behaviors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Behaviors.swift; sourceTree = "<group>"; };
 		753E20E71A84A12100E30460 /* JSTest.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = JSTest.js; sourceTree = "<group>"; };
 		7541D6231AA97528009374FB /* ExceptionHandlingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExceptionHandlingTests.swift; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 				EBD43AAD1A918A8200BB2E6A /* TextLayerBridge.swift */,
 				EBCEBBDE1AA8DC9800B58A6C /* CameraLayerBridge.swift */,
 				961AC2141A93D45D00ED9744 /* SpeechBridge.swift */,
+				61A1BA441ACF51A600780650 /* ShapeLayerBridge.swift */,
 			);
 			name = "Bridged Types";
 			sourceTree = "<group>";
@@ -1537,6 +1540,7 @@
 				6175CE291A7F1B01001E63CE /* BridgeType.swift in Sources */,
 				EBC43D881A81C47A0075272A /* SoundBridge.swift in Sources */,
 				EBC43D781A81999B0075272A /* JSContext+BridgingExtensions.swift in Sources */,
+				61A1BA451ACF51A600780650 /* ShapeLayerBridge.swift in Sources */,
 				EBC43D621A8007320075272A /* ShadowBridge.swift in Sources */,
 				EBD43AAF1A918A8900BB2E6A /* TextLayerBridge.swift in Sources */,
 				EBC43D641A8010770075272A /* ImageBridge.swift in Sources */,

--- a/Prototope/ShapeLayer.swift
+++ b/Prototope/ShapeLayer.swift
@@ -52,7 +52,8 @@ public class ShapeLayer: Layer {
 	/** Creates a regular polygon path with the given number of sides. */
 	convenience public init(polygonCenteredAtPoint centerPoint: Point, radius: Double, numberOfSides: Int, parent: Layer? = nil, name: String? = nil) {
 		let frame = Rect(x: centerPoint.x - radius, y: centerPoint.y - radius, width: radius * 2, height: radius * 2)
-		self.init(segments: Segment.segmentsForPolygonCenteredAtPoint(frame.center, radius: radius, numberOfSides: numberOfSides), closed: true, parent: parent, name: name)
+        self.init(segments: Segment.segmentsForPolygonCenteredAtPoint(Point(x: radius, y: radius), radius: radius, numberOfSides: numberOfSides), closed: true, parent: parent, name: name)
+        
 		self.frame = frame
 	}
 	
@@ -428,10 +429,11 @@ extension Segment {
 		}
 		
 		let angle = Radian(degrees: 360.0 / Double(numberOfSides))
+        let fixedRotation = -M_PI_2 // By decree (and appeal to aesthetics): there should always be a vertex on top.
 		
 		for index in 0..<numberOfSides {
-			let x = centerPoint.x + radius * cos(angle * Double(index))
-			let y = centerPoint.y + radius * sin(angle * Double(index))
+			let x = centerPoint.x + radius * cos(angle * Double(index) + fixedRotation)
+			let y = centerPoint.y + radius * sin(angle * Double(index) + fixedRotation)
 			segments.append(Segment(point: Point(x: x, y: y)))
 		}
 		

--- a/Prototope/ShapeLayer.swift
+++ b/Prototope/ShapeLayer.swift
@@ -104,21 +104,8 @@ public class ShapeLayer: Layer {
 	public func addPoint(point: Point) {
 		self.segments.append(Segment(point: point))
 	}
-	
-	
-	/** Replaces the segment at the given index. Throws an environment exception if the given index isn't in the segment list. */
-	public func replaceSegmentAtIndex(index: Int, withSegment segment: Segment) {
-		if index >= self.segments.count {
-			Environment.currentEnvironment?.exceptionHandler("Tried to replace a path segment at index \(index) but there are only \(self.segments.count) elements")
-			return
-		}
 		
-		self.segments[index] = segment
-		
-	}
-	
-	
-	// TODO(jb): How can this be triggered automatically when mutating the segments?
+    
 	/** Redraws the path. You can call this after you change path segments. */
 	private func setNeedsDisplay() {
 		self.view.setNeedsDisplay()
@@ -334,14 +321,14 @@ public class ShapeLayer: Layer {
 public struct Segment: Printable {
 	
 	/** The anchor point / location of this segment. */
-	public let point: Point
+	public var point: Point
 	
 	
 	/** The control point going in to this segment, used when computing curves. */
-	public let handleIn: Point?
+	public var handleIn: Point?
 	
 	/** The control point coming out of this segment, used when computing curves. */
-	public let handleOut: Point?
+	public var handleOut: Point?
 	
 	
 	/** Initialize a segment with the given point and optional handle points. */

--- a/PrototopeJSBridge/Context.swift
+++ b/PrototopeJSBridge/Context.swift
@@ -82,5 +82,9 @@ public class Context {
 		TextAlignmentBridge.addToContext(context)
 		CameraLayerBridge.addToContext(context)
 		CameraPositionBridge.addToContext(context)
+        ShapeLayerBridge.addToContext(context)
+        SegmentBridge.addToContext(context)
+        LineCapStyleBridge.addToContext(context)
+        LineJoinStyleBridge.addToContext(context)
 	}
 }

--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -33,6 +33,7 @@ import JavaScriptCore
         bridgedShapeLayer.setObject(ShapeLayerOvalBridge.self, forKeyedSubscript: "Oval")
         bridgedShapeLayer.setObject(ShapeLayerRectangleBridge.self, forKeyedSubscript: "Rectangle")
         bridgedShapeLayer.setObject(ShapeLayerLineBridge.self, forKeyedSubscript: "Line")
+        bridgedShapeLayer.setObject(ShapeLayerPolygonBridge.self, forKeyedSubscript: "Polygon")
         context.setObject(bridgedShapeLayer, forKeyedSubscript: "ShapeLayer")
     }
     
@@ -162,6 +163,23 @@ import JavaScriptCore
             super.init(ShapeLayer(lineFromFirstPoint: from, toSecondPoint: to, parent: parentLayer, name: name))
         } else {
             Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Line missing from or to")
+            super.init(args: [:])
+            return nil
+        }
+    }
+}
+
+@objc public class ShapeLayerPolygonBridge: ShapeLayerBridge, ShapeLayerConvenienceConstructorJSExport {
+    public required init?(args: NSDictionary) {
+        let parentLayer = (args["parent"] as? LayerBridge)?.layer
+        let name = args["name"] as? String
+        let center = (args["center"] as? PointBridge)?.point
+        let radius = args["radius"] as? Double
+        let numberOfSides = args["numberOfSides"] as? Double
+        if let center = center, let radius = radius, let numberOfSides = numberOfSides {
+            super.init(ShapeLayer(polygonCenteredAtPoint: center, radius: radius, numberOfSides: Int(numberOfSides), parent: parentLayer, name: name))
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Line missing center, radius, or numberOfSides")
             super.init(args: [:])
             return nil
         }

--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -31,6 +31,7 @@ import JavaScriptCore
         let bridgedShapeLayer = JSValue(object: self, inContext: context)
         bridgedShapeLayer.setObject(ShapeLayerCircleBridge.self, forKeyedSubscript: "Circle")
         bridgedShapeLayer.setObject(ShapeLayerOvalBridge.self, forKeyedSubscript: "Oval")
+        bridgedShapeLayer.setObject(ShapeLayerRectangleBridge.self, forKeyedSubscript: "Rectangle")
         context.setObject(bridgedShapeLayer, forKeyedSubscript: "ShapeLayer")
     }
     
@@ -128,6 +129,22 @@ import JavaScriptCore
             super.init(ShapeLayer(ovalInRectangle: rectangle, parent: parentLayer, name: name))
         } else {
             Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Oval missing rectangle")
+            super.init(args: [:])
+            return nil
+        }
+    }
+}
+
+@objc public class ShapeLayerRectangleBridge: ShapeLayerBridge, ShapeLayerConvenienceConstructorJSExport {
+    public required init?(args: NSDictionary) {
+        let parentLayer = (args["parent"] as? LayerBridge)?.layer
+        let name = args["name"] as? String
+        let rectangle = (args["rectangle"] as? RectBridge)?.rect
+        let cornerRadius = (args["cornerRadius"] as? Double) ?? 0
+        if let rectangle = rectangle {
+            super.init(ShapeLayer(rectangle: rectangle, cornerRadius: cornerRadius, parent: parentLayer, name: name))
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Rectangle missing rectangle")
             super.init(args: [:])
             return nil
         }

--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -1,0 +1,219 @@
+//
+//  ShapeLayerBridge.swift
+//  Prototope
+//
+//  Created by Andy Matuschak on 4/3/15.
+//  Copyright (c) 2015 Khan Academy. All rights reserved.
+//
+
+import Foundation
+import Prototope
+import JavaScriptCore
+
+@objc public protocol ShapeLayerJSExport: JSExport {
+    init?(args: NSDictionary)
+    var segments: [SegmentJSExport] { get set }
+    var firstSegment: SegmentJSExport? { get }
+    var lastSegment: SegmentJSExport? { get }
+    func addPoint(point: PointJSExport)
+    var fillColor: ColorJSExport? { get set }
+    var strokeColor: ColorJSExport? { get set }
+    var strokeWidth: Double { get set }
+    var closed: Bool { get set }
+    var lineCapStyle: JSValue { get set }
+    var lineJoinStyle: JSValue { get set }
+}
+
+@objc public class ShapeLayerBridge: LayerBridge, ShapeLayerJSExport, BridgeType {
+    var shapeLayer: ShapeLayer { return layer as! ShapeLayer }
+    
+    public override class func addToContext(context: JSContext) {
+        context.setObject(self, forKeyedSubscript: "ShapeLayer")
+    }
+    
+    public required init?(args: NSDictionary) {
+        let parentLayer = (args["parent"] as? LayerBridge)?.layer
+        let name = args["name"] as? String
+        let segments = ((args["segments"] as? [SegmentBridge]) ?? []).map { $0.segment! }
+        let closed = (args["closed"] as? Bool) ?? false
+        super.init(ShapeLayer(segments: segments, closed: closed, parent: parentLayer, name: name))
+    }
+    
+    public var segments: [SegmentJSExport] {
+        get { return shapeLayer.segments.map { SegmentBridge($0) } }
+        set { shapeLayer.segments = newValue.map { ($0 as! SegmentBridge).segment } }
+    }
+    
+    public var firstSegment: SegmentJSExport? {
+        return shapeLayer.firstSegment != nil ? SegmentBridge(shapeLayer.firstSegment!) : nil
+    }
+    
+    public var lastSegment: SegmentJSExport? {
+        return shapeLayer.lastSegment != nil ? SegmentBridge(shapeLayer.lastSegment!) : nil
+    }
+    
+    public func addPoint(point: PointJSExport) {
+        shapeLayer.addPoint((point as! PointBridge).point)
+    }
+    
+    public var fillColor: ColorJSExport? {
+        get { return shapeLayer.fillColor != nil ? ColorBridge(shapeLayer.fillColor!) : nil }
+        set { shapeLayer.fillColor = (newValue as! ColorBridge).color }
+    }
+
+    public var strokeColor: ColorJSExport? {
+        get { return shapeLayer.strokeColor != nil ? ColorBridge(shapeLayer.strokeColor!) : nil }
+        set { shapeLayer.strokeColor = (newValue as! ColorBridge).color }
+    }
+    
+    public var strokeWidth: Double {
+        get { return shapeLayer.strokeWidth }
+        set { shapeLayer.strokeWidth = newValue }
+    }
+    
+    public var closed: Bool {
+        get { return shapeLayer.closed }
+        set { shapeLayer.closed = newValue }
+    }
+    
+    public var lineCapStyle: JSValue {
+        get { return LineCapStyleBridge.encodeLineCapStyle(shapeLayer.lineCapStyle, inContext: JSContext.currentContext()) }
+        set { shapeLayer.lineCapStyle = LineCapStyleBridge.decodeLineCapStyle(newValue) }
+    }
+
+    public var lineJoinStyle: JSValue {
+        get { return LineJoinStyleBridge.encodeLineJoinStyle(shapeLayer.lineJoinStyle, inContext: JSContext.currentContext()) }
+        set { shapeLayer.lineJoinStyle = LineJoinStyleBridge.decodeLineJoinStyle(newValue) }
+    }
+}
+
+@objc public protocol SegmentJSExport: JSExport {
+    init?(args: JSValue)
+    var point: PointJSExport { get set }
+    var handleIn: PointJSExport? { get set }
+    var handleOut: PointJSExport? { get set }
+}
+
+@objc public class SegmentBridge: NSObject, SegmentJSExport, BridgeType {
+    var segment: Segment!
+    
+    public static func addToContext(context: JSContext) {
+        context.setObject(self, forKeyedSubscript: "Segment")
+    }
+    
+    required public init?(args: JSValue) {
+        var segment = Segment(point: Point.zero)
+        if let pointBridge = args.toObjectOfClass(PointBridge.self) as! PointBridge? {
+            segment.point = pointBridge.point
+        } else if let pointBridge = args.objectForKeyedSubscript("point").toObjectOfClass(PointBridge.self) as! PointBridge? {
+            segment.point = pointBridge.point
+            segment.handleIn = (args.objectForKeyedSubscript("handleIn").toObjectOfClass(PointBridge.self) as! PointBridge?)?.point
+            segment.handleOut = (args.objectForKeyedSubscript("handleOut").toObjectOfClass(PointBridge.self) as! PointBridge?)?.point
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("Segment cannot be initialized without a point")
+            super.init()
+            return nil
+        }
+        
+        self.segment = segment
+        super.init()
+    }
+    
+    init(_ segment: Segment) {
+        self.segment = segment
+    }
+    
+    public var point: PointJSExport {
+        get { return PointBridge(segment.point) }
+        set { segment.point = (newValue as! PointBridge).point }
+    }
+    
+    public var handleIn: PointJSExport? {
+        get { return segment.handleIn != nil ? PointBridge(segment.handleIn!) : nil }
+        set { segment.handleIn = (newValue as! PointBridge).point }
+    }
+
+    public var handleOut: PointJSExport? {
+        get { return segment.handleOut != nil ? PointBridge(segment.handleOut!) : nil }
+        set { segment.handleOut = (newValue as! PointBridge).point }
+    }
+}
+
+public class LineCapStyleBridge: NSObject, BridgeType {
+    enum RawLineCapStyle: Int {
+        case Butt = 0
+        case Round = 1
+        case Square = 2
+    }
+    
+    public class func addToContext(context: JSContext) {
+        let lineCapStyleObject = JSValue(newObjectInContext: context)
+        lineCapStyleObject.setObject(RawLineCapStyle.Butt.rawValue, forKeyedSubscript: "Butt")
+        lineCapStyleObject.setObject(RawLineCapStyle.Round.rawValue, forKeyedSubscript: "Round")
+        lineCapStyleObject.setObject(RawLineCapStyle.Square.rawValue, forKeyedSubscript: "Square")
+        context.setObject(lineCapStyleObject, forKeyedSubscript: "LineCapStyle")
+    }
+    
+    public class func encodeLineCapStyle(lineCapStyle: Prototope.ShapeLayer.LineCapStyle, inContext context: JSContext) -> JSValue {
+        var rawLineCapStyle: RawLineCapStyle
+        switch lineCapStyle {
+        case .Butt: rawLineCapStyle = .Butt
+        case .Round: rawLineCapStyle = .Round
+        case .Square: rawLineCapStyle = .Square
+        }
+        return JSValue(int32: Int32(rawLineCapStyle.rawValue), inContext: context)
+    }
+    
+    public class func decodeLineCapStyle(bridgedLineCapStyle: JSValue) -> Prototope.ShapeLayer.LineCapStyle! {
+        if let rawLineCapStyle = RawLineCapStyle(rawValue: Int(bridgedLineCapStyle.toInt32())) {
+            switch rawLineCapStyle {
+            case .Butt: return .Butt
+            case .Round: return .Round
+            case .Square: return .Square
+            }
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("Unknown line cap style: \(bridgedLineCapStyle)")
+            return nil
+        }
+    }
+}
+
+public class LineJoinStyleBridge: NSObject, BridgeType {
+    enum RawLineJoinStyle: Int {
+        case Miter = 0
+        case Round = 1
+        case Bevel = 2
+    }
+    
+    public class func addToContext(context: JSContext) {
+        let lineJoinStyleObject = JSValue(newObjectInContext: context)
+        lineJoinStyleObject.setObject(RawLineJoinStyle.Miter.rawValue, forKeyedSubscript: "Miter")
+        lineJoinStyleObject.setObject(RawLineJoinStyle.Round.rawValue, forKeyedSubscript: "Round")
+        lineJoinStyleObject.setObject(RawLineJoinStyle.Bevel.rawValue, forKeyedSubscript: "Bevel")
+        context.setObject(lineJoinStyleObject, forKeyedSubscript: "LineJoinStyle")
+    }
+    
+    public class func encodeLineJoinStyle(lineJoinStyle: Prototope.ShapeLayer.LineJoinStyle, inContext context: JSContext) -> JSValue {
+        var rawLineJoinStyle: RawLineJoinStyle
+        switch lineJoinStyle {
+        case .Miter: rawLineJoinStyle = .Miter
+        case .Round: rawLineJoinStyle = .Round
+        case .Bevel: rawLineJoinStyle = .Bevel
+        }
+        return JSValue(int32: Int32(rawLineJoinStyle.rawValue), inContext: context)
+    }
+    
+    public class func decodeLineJoinStyle(bridgedLineJoinStyle: JSValue) -> Prototope.ShapeLayer.LineJoinStyle! {
+        if let rawLineJoinStyle = RawLineJoinStyle(rawValue: Int(bridgedLineJoinStyle.toInt32())) {
+            switch rawLineJoinStyle {
+            case .Miter: return .Miter
+            case .Round: return .Round
+            case .Bevel: return .Bevel
+            }
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("Unknown line join style: \(bridgedLineJoinStyle)")
+            return nil
+        }
+    }
+}
+

--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -32,6 +32,7 @@ import JavaScriptCore
         bridgedShapeLayer.setObject(ShapeLayerCircleBridge.self, forKeyedSubscript: "Circle")
         bridgedShapeLayer.setObject(ShapeLayerOvalBridge.self, forKeyedSubscript: "Oval")
         bridgedShapeLayer.setObject(ShapeLayerRectangleBridge.self, forKeyedSubscript: "Rectangle")
+        bridgedShapeLayer.setObject(ShapeLayerLineBridge.self, forKeyedSubscript: "Line")
         context.setObject(bridgedShapeLayer, forKeyedSubscript: "ShapeLayer")
     }
     
@@ -145,6 +146,22 @@ import JavaScriptCore
             super.init(ShapeLayer(rectangle: rectangle, cornerRadius: cornerRadius, parent: parentLayer, name: name))
         } else {
             Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Rectangle missing rectangle")
+            super.init(args: [:])
+            return nil
+        }
+    }
+}
+
+@objc public class ShapeLayerLineBridge: ShapeLayerBridge, ShapeLayerConvenienceConstructorJSExport {
+    public required init?(args: NSDictionary) {
+        let parentLayer = (args["parent"] as? LayerBridge)?.layer
+        let name = args["name"] as? String
+        let from = (args["from"] as? PointBridge)?.point
+        let to = (args["to"] as? PointBridge)?.point
+        if let from = from, let to = to {
+            super.init(ShapeLayer(lineFromFirstPoint: from, toSecondPoint: to, parent: parentLayer, name: name))
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Line missing from or to")
             super.init(args: [:])
             return nil
         }

--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -30,6 +30,7 @@ import JavaScriptCore
     public override class func addToContext(context: JSContext) {
         let bridgedShapeLayer = JSValue(object: self, inContext: context)
         bridgedShapeLayer.setObject(ShapeLayerCircleBridge.self, forKeyedSubscript: "Circle")
+        bridgedShapeLayer.setObject(ShapeLayerOvalBridge.self, forKeyedSubscript: "Oval")
         context.setObject(bridgedShapeLayer, forKeyedSubscript: "ShapeLayer")
     }
     
@@ -93,10 +94,15 @@ import JavaScriptCore
     }
 }
 
+
 // MARK: - Convenience constructors
+
+// We want prototypers to be able to say "new ShapeLayer.Circle({center: pt, radius: r})". These stub classes exist only to have bridged constructors.
+
 @objc public protocol ShapeLayerConvenienceConstructorJSExport: JSExport {
     init?(args: NSDictionary)
 }
+
 @objc public class ShapeLayerCircleBridge: ShapeLayerBridge, ShapeLayerConvenienceConstructorJSExport {
     public required init?(args: NSDictionary) {
         let parentLayer = (args["parent"] as? LayerBridge)?.layer
@@ -112,6 +118,22 @@ import JavaScriptCore
         }
     }
 }
+
+@objc public class ShapeLayerOvalBridge: ShapeLayerBridge, ShapeLayerConvenienceConstructorJSExport {
+    public required init?(args: NSDictionary) {
+        let parentLayer = (args["parent"] as? LayerBridge)?.layer
+        let name = args["name"] as? String
+        let rectangle = (args["rectangle"] as? RectBridge)?.rect
+        if let rectangle = rectangle {
+            super.init(ShapeLayer(ovalInRectangle: rectangle, parent: parentLayer, name: name))
+        } else {
+            Environment.currentEnvironment!.exceptionHandler("ShapeLayer.Oval missing rectangle")
+            super.init(args: [:])
+            return nil
+        }
+    }
+}
+
 
 //============================================================================
 // MARK: - Segment


### PR DESCRIPTION
Also included:
* an example
* fixed a positioning bug in polygon creation
* made polygons always have one vertex at the top
* made `Segment`'s fields mutable
* removed redundant `ShapeLayer.replaceSegment` API

![example gif](https://dl.dropboxusercontent.com/s/yx2o4g14mal8wpj/FF863C81-AA93-4FC0-A616-84AC5C83E784-38300-0001590C55020402.gif?dl=0)

/cc @jbrennan 