### PR TITLE
Bridge the Point.slopeToPoint() function.

### DIFF
--- a/PrototopeJSBridge/GeometryBridge.swift
+++ b/PrototopeJSBridge/GeometryBridge.swift
@@ -19,6 +19,7 @@ import Prototope
 	static var zero: PointJSExport { get } // exported manually
 	init(args: NSDictionary) 
 	func distanceToPoint(point: PointJSExport) -> Double
+	func slopeToPoint(point: PointJSExport) -> Double
 	var length: Double { get }
 
 	func equals(point: PointJSExport) -> Bool
@@ -56,6 +57,11 @@ import Prototope
 
 	public func distanceToPoint(other: PointJSExport) -> Double {
 		return point.distanceToPoint((other as JSExport as! PointBridge).point)
+	}
+	
+	
+	public func slopeToPoint(point: PointJSExport) -> Double {
+		return self.point.slopeToPoint((point as JSExport as! PointBridge).point) ?? 0.0
 	}
 
 	public var length: Double { return point.length }

--- a/PrototopeJSBridge/GeometryBridge.swift
+++ b/PrototopeJSBridge/GeometryBridge.swift
@@ -19,7 +19,7 @@ import Prototope
 	static var zero: PointJSExport { get } // exported manually
 	init(args: NSDictionary) 
 	func distanceToPoint(point: PointJSExport) -> Double
-	func slopeToPoint(point: PointJSExport) -> Double
+	func slopeToPoint(point: PointJSExport) -> JSValue
 	var length: Double { get }
 
 	func equals(point: PointJSExport) -> Bool
@@ -60,8 +60,10 @@ import Prototope
 	}
 	
 	
-	public func slopeToPoint(point: PointJSExport) -> Double {
-		return self.point.slopeToPoint((point as JSExport as! PointBridge).point) ?? 0.0
+	public func slopeToPoint(point: PointJSExport) -> JSValue {
+		let slope = self.point.slopeToPoint((point as JSExport as! PointBridge).point)
+		let context = JSContext.currentContext()
+		return slope != nil ? JSValue(double: slope!, inContext: context) : JSValue(undefinedInContext: context)
 	}
 
 	public var length: Double { return point.length }

--- a/PrototopeTestApp/JSTest.js
+++ b/PrototopeTestApp/JSTest.js
@@ -52,6 +52,9 @@ scrollLayer.updateScrollableSizeToFitSublayers();
 scrollLayer.moveToRightOfSiblingLayer({siblingLayer: layer, margin: 10.0});
 
 Speech.say({text: " "}); // silent, but here for illustration.
-
+var p1 = new Point({x: 50, y: 100});
+var p2 = new Point({x: 100, y: 60});
+var slope = p1.slopeToPoint(p2);
+console.log("slope " + slope);
 console.log("Hello, world!");
 "Done JSTest.js";


### PR DESCRIPTION
Is it possible (or does it make sense) to bridge an optional type?

The slope function is optional for the case where the slope is infinite/undefined (i.e., there's a divide by zero). For the bridge I'm just returning 0 because it seems more sensible to do this than really worry about it too much. Thoughts?

[Fixes #66]