### PR TITLE
Fix Layer.globalPosition's coordinate space conversion

### DIFF
--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -292,8 +292,20 @@ public class Layer: Equatable, Hashable {
 
 	/** Returns the layer's position in the root layer's coordinate space. */
 	public var globalPosition: Point {
-		get { return convertLocalPointToGlobalPoint(position) }
-		set { position = convertGlobalPointToLocalPoint(newValue) }
+		get {
+			if let parent = parent {
+				return parent.convertLocalPointToGlobalPoint(position)
+			} else {
+				return position
+			}
+		}
+		set {
+			if let parent = parent {
+				position = parent.convertGlobalPointToLocalPoint(newValue)
+			} else {
+				position = newValue
+			}
+		}
 	}
 
 	/** Returns whether the layer contains a given point, interpreted in the root layer's


### PR DESCRIPTION
`position` is expressed in the parent’s coordinate space, not local space, so we have to use the parent to convert.