### PR TITLE
Sounds that are playing should keep playing even if you stop referencing them

### DIFF
--- a/Prototope/Sound.swift
+++ b/Prototope/Sound.swift
@@ -75,5 +75,5 @@ public struct Sound: Printable {
 	}
 }
 
-private var playingAVAudioPlayers = Set<(AVAudioPlayer)>()
-private var playingAVAudioPlayerDelegates = Set<(Sound.AVAudioPlayerDelegate)>()
+private var playingAVAudioPlayers = Set<AVAudioPlayer>()
+private var playingAVAudioPlayerDelegates = Set<Sound.AVAudioPlayerDelegate>()

--- a/Prototope/Sound.swift
+++ b/Prototope/Sound.swift
@@ -57,7 +57,7 @@ public struct Sound: Printable {
 		playingAVAudioPlayers.remove(player)
 	}
 
-	public static var supportedExtensions = ["caf", "aif", "aiff", "wav"]
+	public static let supportedExtensions = ["caf", "aif", "aiff", "wav"]
 
 	// Fancy scheme to keep playing AVAudioPlayers from deallocating while they're playing.
 	@objc private class AVAudioPlayerDelegate: NSObject, AVFoundation.AVAudioPlayerDelegate {


### PR DESCRIPTION
I wanted to write JS code like:

```
new Sound({name: “foo”}).play()
```

But the garbage collector would occasionally collect the `Sound` and stop it from playing completely!