### PR TITLE
Shape layers should also be bridged as layers

### DIFF
--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -26,7 +26,7 @@ import JavaScriptCore
     var lineJoinStyle: JSValue { get set }
 }
 
-@objc public class ShapeLayerBridge: LayerBridge, ShapeLayerJSExport, BridgeType {
+@objc public class ShapeLayerBridge: LayerBridge, ShapeLayerJSExport, LayerJSExport, BridgeType {
     var shapeLayer: ShapeLayer { return layer as! ShapeLayer }
     
     public override class func addToContext(context: JSContext) {


### PR DESCRIPTION
We were only bridging `ShapeLayer` APIs, not inheriting `Layer`’s APIs.