### PR TITLE
Image from text

### DIFF
--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -1440,7 +1440,7 @@
 		EB306C0119DF77CC00113FA3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftMigration = 0700;
+				LastSwiftMigration = 0720;
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = "Khan Academy";

--- a/Prototope/Geometry.swift
+++ b/Prototope/Geometry.swift
@@ -250,12 +250,12 @@ public struct Rect: Equatable {
     }
     
     /** Convenience function. Returns a Rect constructed by insetting the receiver. */
-    public func inset(vertical: Double = 0, horizontal: Double = 0) -> Rect {
+    public func inset(vertical vertical: Double = 0, horizontal: Double = 0) -> Rect {
         return inset(top: vertical, right: horizontal, bottom: vertical, left: horizontal)
     }
     
     /** Convenience function. Returns a Rect constructed by insetting the receiver. */
-    public func inset(value: Double = 0) -> Rect {
+    public func inset(value value: Double = 0) -> Rect {
         return inset(top: value, right: value, bottom: value, left: value)
     }
     

--- a/Prototope/Image.swift
+++ b/Prototope/Image.swift
@@ -56,3 +56,29 @@ public struct Image: CustomStringConvertible {
 		return self.name
 	}
 }
+
+
+extension Image {
+	
+	/** Creates an image by rendering the given text into an image. */
+	public init(text: String, font: SystemFont = SystemFont.boldSystemFontOfSize(SystemFont.systemFontSize()), textColor: Color = Color.black) {
+		
+		self.init(Image.imageFromText(text, font: font, textColor: textColor))
+	}
+	
+	static func imageFromText(text: String, font: SystemFont = SystemFont.boldSystemFontOfSize(SystemFont.systemFontSize()), textColor: Color = Color.black) -> SystemImage {
+		let attributes = [NSFontAttributeName: font, NSForegroundColorAttributeName: textColor.systemColor]
+		let size = (text as NSString).sizeWithAttributes(attributes)
+		
+		let isOpaque = false
+		let automaticScale: CGFloat = 0.0
+		UIGraphicsBeginImageContextWithOptions(size, isOpaque, automaticScale)
+		(text as NSString).drawAtPoint(CGPoint(), withAttributes: attributes)
+		
+		let image = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+		
+		return image
+	}
+}
+

--- a/Prototope/Layer+Layout.swift
+++ b/Prototope/Layer+Layout.swift
@@ -58,7 +58,7 @@ extension Layer {
 	
 	
 	/** Moves the receiver so that its right side is aligned with the right side of its parent layer. */
-	public func moveToRightSideOfParentLayer(margin: Double = 0.0) {
+	public func moveToRightSideOfParentLayer(margin margin: Double = 0.0) {
 		if let parent = self.parent {
 			self.originX = floor(parent.width - self.width - margin)
 		}
@@ -66,7 +66,7 @@ extension Layer {
 	
 	
 	/** Moves the receiver so that its left side is aligned with the left side of its parent layer. */
-	public func moveToLeftSideOfParentLayer(margin: Double = 0.0) {
+	public func moveToLeftSideOfParentLayer(margin margin: Double = 0.0) {
 		if self.parent != nil {
 			self.originX = margin
 		}
@@ -74,7 +74,7 @@ extension Layer {
 	
 	
 	/** Moves the receiver so that its top side is aligned with the top side of its parent layer. */
-	public func moveToTopSideOfParentLayer(margin: Double = 0.0) {
+	public func moveToTopSideOfParentLayer(margin margin: Double = 0.0) {
 		if self.parent != nil {
 			self.originY = margin
 		}
@@ -82,7 +82,7 @@ extension Layer {
 	
 	
 	/** Moves the receiver so that its bottom side is aligned with the bottom side of its parent layer. */
-	public func moveToBottomSideOfParentLayer(margin: Double = 0.0) {
+	public func moveToBottomSideOfParentLayer(margin margin: Double = 0.0) {
 		if let parent = self.parent {
 			self.originY = floor(parent.height - self.height - margin)
 		}

--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -64,6 +64,16 @@ public class Layer: Equatable {
 		self.image = Image(name: imageName)
 		imageDidChange()
 	}
+	
+	
+	/** Convenience initializer; makes a layer which displays the given image.
+		The layer will adopt its size from the image. */
+	public convenience init(parent: Layer?, image: Image) {
+		self.init(parent: parent)
+		self.image = image
+		imageDidChange()
+	}
+	
 
 	/** Creates a Prototope Layer by wrapping a CALayer. The result may not have
 	access to all the normal Prototope functionality--beware! You should mostly

--- a/PrototopeJSBridge/AnimationBridge.swift
+++ b/PrototopeJSBridge/AnimationBridge.swift
@@ -10,7 +10,7 @@ import Foundation
 import JavaScriptCore
 import Prototope
 
-let animateWithDurationBridgingTrampoline: @objc_block JSValue -> Void = { args in
+let animateWithDurationBridgingTrampoline: @convention(block) JSValue -> Void = { args in
 	let durationValue = args.valueForProperty("duration")
 	let curveValue = args.valueForProperty("curve")
 	let animationsHandler = args.valueForProperty("animations")

--- a/PrototopeJSBridge/AnimationBridge.swift
+++ b/PrototopeJSBridge/AnimationBridge.swift
@@ -16,16 +16,16 @@ let animateWithDurationBridgingTrampoline: @objc_block JSValue -> Void = { args 
 	let animationsHandler = args.valueForProperty("animations")
 	let completionHandler = args.valueForProperty("completionHandler")
 
-	if !durationValue.isUndefined() && !animationsHandler.isUndefined() {
+	if !durationValue.isUndefined && !animationsHandler.isUndefined {
 		let animationsHandler: () -> Void = {
 			animationsHandler.callWithArguments([])
 			return
 		}
-		let completionHandler: (() -> Void)? = completionHandler.isUndefined() ? nil : {
+		let completionHandler: (() -> Void)? = completionHandler.isUndefined ? nil : {
 			completionHandler.callWithArguments([])
 			return
 		}
-		if curveValue.isUndefined() {
+		if curveValue.isUndefined {
 			Prototope.Layer.animateWithDuration(
 				durationValue.toDouble(),
 				animations: animationsHandler,

--- a/PrototopeJSBridge/BehaviorBridge.swift
+++ b/PrototopeJSBridge/BehaviorBridge.swift
@@ -52,8 +52,8 @@ func behaviorForBehaviorBridge(behaviorBridge: BehaviorBridgeType) -> BehaviorTy
         let otherLayerValue = args.valueForProperty("with")
         let handler = args.valueForProperty("handler")
         
-        if let otherLayer = (otherLayerValue.toObject() as? JSExport as? LayerBridge)?.layer where !otherLayerValue.isUndefined(),
-            let handler = handler where !handler.isUndefined() {
+        if let otherLayer = (otherLayerValue.toObject() as? JSExport as? LayerBridge)?.layer where !otherLayerValue.isUndefined,
+            let handler = handler where !handler.isUndefined {
                 collisionBehavior = CollisionBehavior(with: otherLayer, handler: { kind in
                     let bridgedKind = CollisionBehaviorKindBridge.encodeKind(kind, inContext: handler.context)
                     handler.callWithArguments([bridgedKind])
@@ -125,7 +125,7 @@ public class CollisionBehaviorKindBridge: NSObject, BridgeType {
     required public init?(args: JSValue) {
         let handler = args.objectForKeyedSubscript("handler")
         
-        if let handler = handler where !handler.isUndefined() {
+        if let handler = handler where !handler.isUndefined {
             actionBehavior = ActionBehavior { layer in
                 handler.callWithArguments([LayerBridge(layer)!])
             }

--- a/PrototopeJSBridge/CameraLayerBridge.swift
+++ b/PrototopeJSBridge/CameraLayerBridge.swift
@@ -14,7 +14,7 @@ import JavaScriptCore
 	var cameraPosition: JSValue { get set }
 }
 
-@objc public class CameraLayerBridge: LayerBridge, CameraLayerJSExport, BridgeType {
+@objc public class CameraLayerBridge: LayerBridge, CameraLayerJSExport {
 	var cameraLayer: CameraLayer { return layer as! CameraLayer }
 
 	public override class func addToContext(context: JSContext) {

--- a/PrototopeJSBridge/Context.swift
+++ b/PrototopeJSBridge/Context.swift
@@ -18,7 +18,7 @@ public class Context {
 					if handlingException {
 						// Exception thrown while normalizing or presenting error -- this indicates a mistake in this code, but bail out here to prevent an infinite loop of exceptions
 						let stack = value.valueForProperty("stack")
-						println("JS error thrown while handling error:\n\(value)\n\n\(stack)")
+						print("JS error thrown while handling error:\n\(value)\n\n\(stack)")
 						abort()
 					}
 					handlingException = true
@@ -33,7 +33,7 @@ public class Context {
 	}
 
 	public var consoleLogHandler: (String -> Void)? = { str in
-		println(str)
+		print(str)
 	}
 
 	private let vm = JSVirtualMachine()
@@ -52,7 +52,7 @@ public class Context {
 
 	public func evaluateScript(script: String!) -> JSValue {
 		let transformed = context.objectForKeyedSubscript("Protoscope").invokeMethod("transform", withArguments: [script])
-		if transformed.isUndefined() {
+		if transformed.isUndefined {
 			// In case of a transform error, an exception will be thrown (and handled by the exception handler), so we get undefined back here and can pass that up in turn.
 			return transformed
 		}
@@ -86,7 +86,7 @@ public class Context {
 
 	private func loadRuntime() {
 		let path = NSBundle.mainBundle().pathForResource("protoscope-bundle", ofType: "js")
-		context.evaluateScript(String(contentsOfFile: path!, encoding: NSUTF8StringEncoding, error: nil), withSourceURL: NSURL(string: "protoscope-bundle.js"))
+		context.evaluateScript(try? String(contentsOfFile: path!, encoding: NSUTF8StringEncoding), withSourceURL: NSURL(string: "protoscope-bundle.js"))
 	}
 
 	private func addBridgedTypes() {

--- a/PrototopeJSBridge/Context.swift
+++ b/PrototopeJSBridge/Context.swift
@@ -91,7 +91,7 @@ public class Context {
 
 	private func addBridgedTypes() {
 		let console = JSValue(newObjectInContext: context)
-		let loggingTrampoline: @objc_block JSValue -> Void = { [weak self] value in
+		let loggingTrampoline: @convention(block) JSValue -> Void = { [weak self] value in
 			self?.consoleLogHandler?(value.toString())
 			return
 		}
@@ -107,7 +107,7 @@ public class Context {
 				
 				let bridgedConstructor = JSValue(object: bridgedNSObject, inContext: context)
 				let prototype = bridgedConstructor.valueForProperty("prototype")
-				let toStringImpl: @objc_block () -> String = {
+				let toStringImpl: @convention(block) () -> String = {
 					let this = JSContext.currentThis()
 					return this.description 
 				}

--- a/PrototopeJSBridge/GestureBridge.swift
+++ b/PrototopeJSBridge/GestureBridge.swift
@@ -32,7 +32,7 @@ import JavaScriptCore
 		let globalLocationValue = args.valueForProperty("globalLocation")
 		let timestampValue = args.valueForProperty("timestamp")
 
-		if !globalLocationValue.isUndefined() && !timestampValue.isUndefined() {
+		if !globalLocationValue.isUndefined && !timestampValue.isUndefined {
 			touchSample = Prototope.TouchSample(
 				globalLocation: (globalLocationValue.toObject() as! JSExport as! PointBridge).point,
 				timestamp: Prototope.Timestamp(timestampValue.toDouble())
@@ -98,7 +98,7 @@ extension JSValue: SampleType {}
 		let samplesValue = args.valueForProperty("samples")
 		let idValue = args.valueForProperty("id")
 
-		if !samplesValue.isUndefined() && !idValue.isUndefined() {
+		if !samplesValue.isUndefined && !idValue.isUndefined {
 			let sampleBridges = samplesValue.toArray().map { JSValue(object: $0, inContext: JSContext.currentContext())! }
 			sampleSequence = Prototope.SampleSequence(samples: sampleBridges, id: idValue)
 			super.init()
@@ -151,7 +151,7 @@ extension JSValue: SampleType {}
 		let samplesValue = args.valueForProperty("samples")
 		let idValue = args.valueForProperty("id")
 
-		if !samplesValue.isUndefined() && !idValue.isUndefined() {
+		if !samplesValue.isUndefined && !idValue.isUndefined {
 			let sampleBridges = samplesValue.toArray() as! [TouchSampleBridge]
 			touchSequence = Prototope.TouchSequence(
 				samples: sampleBridges.map { $0.touchSample },
@@ -257,15 +257,15 @@ func gestureForGestureBridge(gestureBridge: GestureBridgeType) -> GestureType {
 
 	public required init?(args: JSValue) {
 		let handler = args.valueForProperty("handler")
-		if !handler.isUndefined() {
+		if !handler.isUndefined {
 			let cancelsTouchesInLayerValue = args.valueForProperty("cancelsTouchesInLayer")
-			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined() ? true : cancelsTouchesInLayerValue.toBool()
+			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined ? true : cancelsTouchesInLayerValue.toBool()
 
 			let numberOfTapsRequiredValue = args.valueForProperty("numberOfTapsRequired")
-			let numberOfTapsRequired = numberOfTapsRequiredValue.isUndefined() ? 1 : Int(numberOfTapsRequiredValue.toInt32())
+			let numberOfTapsRequired = numberOfTapsRequiredValue.isUndefined ? 1 : Int(numberOfTapsRequiredValue.toInt32())
 
 			let numberOfTouchesRequiredValue = args.valueForProperty("numberOfTouchesRequired")
-			let numberOfTouchesRequired = numberOfTouchesRequiredValue.isUndefined() ? 1 : Int(numberOfTouchesRequiredValue.toInt32())
+			let numberOfTouchesRequired = numberOfTouchesRequiredValue.isUndefined ? 1 : Int(numberOfTouchesRequiredValue.toInt32())
 
 			tapGesture = TapGesture(
 				cancelsTouchesInLayer: cancelsTouchesInLayer,
@@ -355,15 +355,15 @@ public class ContinuousGesturePhaseBridge: NSObject, BridgeType {
 
 	public required init?(args: JSValue) {
 		let handler = args.valueForProperty("handler")
-		if !handler.isUndefined() {
+		if !handler.isUndefined {
 			let cancelsTouchesInLayerValue = args.valueForProperty("cancelsTouchesInLayer")
-			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined() ? true : cancelsTouchesInLayerValue.toBool()
+			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined ? true : cancelsTouchesInLayerValue.toBool()
 
 			let minimumNumberOfTouchesValue = args.valueForProperty("minimumNumberOfTouches")
-			let minimumNumberOfTouches = minimumNumberOfTouchesValue.isUndefined() ? 1 : Int(minimumNumberOfTouchesValue.toInt32())
+			let minimumNumberOfTouches = minimumNumberOfTouchesValue.isUndefined ? 1 : Int(minimumNumberOfTouchesValue.toInt32())
 
 			let maximumNumberOfTouchesValue = args.valueForProperty("maximumNumberOfTouches")
-			let maximumNumberOfTouches = maximumNumberOfTouchesValue.isUndefined() ? Int.max : Int(maximumNumberOfTouchesValue.toInt32())
+			let maximumNumberOfTouches = maximumNumberOfTouchesValue.isUndefined ? Int.max : Int(maximumNumberOfTouchesValue.toInt32())
 
 			panGesture = PanGesture(
 				minimumNumberOfTouches: minimumNumberOfTouches,
@@ -450,9 +450,9 @@ public class ContinuousGesturePhaseBridge: NSObject, BridgeType {
 
 	public required init?(args: JSValue) {
 		let handler = args.valueForProperty("handler")
-		if !handler.isUndefined() {
+		if !handler.isUndefined {
 			let cancelsTouchesInLayerValue = args.valueForProperty("cancelsTouchesInLayer")
-			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined() ? true : cancelsTouchesInLayerValue.toBool()
+			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined ? true : cancelsTouchesInLayerValue.toBool()
 
 			rotationGesture = RotationGesture(
 				cancelsTouchesInLayer: cancelsTouchesInLayer,
@@ -534,9 +534,9 @@ public class ContinuousGesturePhaseBridge: NSObject, BridgeType {
 
 	public required init?(args: JSValue) {
 		let handler = args.valueForProperty("handler")
-		if !handler.isUndefined() {
+		if !handler.isUndefined {
 			let cancelsTouchesInLayerValue = args.valueForProperty("cancelsTouchesInLayer")
-			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined() ? true : cancelsTouchesInLayerValue.toBool()
+			let cancelsTouchesInLayer = cancelsTouchesInLayerValue.isUndefined ? true : cancelsTouchesInLayerValue.toBool()
 
 			pinchGesture = PinchGesture(
 				cancelsTouchesInLayer: cancelsTouchesInLayer,

--- a/PrototopeJSBridge/HeartbeatBridge.swift
+++ b/PrototopeJSBridge/HeartbeatBridge.swift
@@ -27,7 +27,7 @@ import JavaScriptCore
 	required public init?(args: JSValue) {
 		super.init()
 		let handler = args.objectForKeyedSubscript("handler")
-		if !handler.isUndefined() {
+		if !handler.isUndefined {
 			heartbeat = Heartbeat { [weak self] heartbeat in
 				if let strongSelf = self {
 					handler.callWithArguments([strongSelf])

--- a/PrototopeJSBridge/ImageBridge.swift
+++ b/PrototopeJSBridge/ImageBridge.swift
@@ -25,6 +25,18 @@ import JavaScriptCore
 		if let imageName = args["name"] as! String? {
 			image = Image(name: imageName)
 			super.init()
+		} else if let text = args["text"] as! String? {
+			
+			// TODO(jb): Replace this with a FontBridge type.
+			let fontName = (args["fontName"] as! String?) ?? "Helvetica"
+			let fontSize = (args["fontSize"] as! Double?) ?? 18
+			let font = SystemFont(name: fontName, size: CGFloat(fontSize))
+			
+			let textColor = (args["textColor"] as! ColorBridge).color ?? Color.black
+			
+			image = Image(text: text, font: font!, textColor: textColor)
+			
+			super.init()
 		} else {
 			super.init()
 			return nil

--- a/PrototopeJSBridge/LayerBridge.swift
+++ b/PrototopeJSBridge/LayerBridge.swift
@@ -110,7 +110,7 @@ import JavaScriptCore
     func moveToCenterOfParentLayer()
 }
 
-@objc public class LayerBridge: NSObject, LayerJSExport, CustomStringConvertible, BridgeType {
+@objc public class LayerBridge: NSObject, LayerJSExport, BridgeType {
     
     public class func addToContext(context: JSContext) {
         context.setObject(LayerBridge.self, forKeyedSubscript: "Layer")
@@ -358,7 +358,7 @@ import JavaScriptCore
         let output = JSValue(newObjectInContext: context)
         for (_, sequence) in mapping {
 			let bridgedSequence = bridgeTouchSequence(sequence, context: context)
-            output.setObject(bridgedSequence, forKeyedSubscript: bridgedSequence.id)
+            output.setObject(bridgedSequence, forKeyedSubscript: bridgedSequence.id.toString())
         }
         return output
     }

--- a/PrototopeJSBridge/LayerBridge.swift
+++ b/PrototopeJSBridge/LayerBridge.swift
@@ -110,7 +110,7 @@ import JavaScriptCore
     func moveToCenterOfParentLayer()
 }
 
-@objc public class LayerBridge: NSObject, LayerJSExport, Printable, BridgeType {
+@objc public class LayerBridge: NSObject, LayerJSExport, CustomStringConvertible, BridgeType {
     
     public class func addToContext(context: JSContext) {
         context.setObject(LayerBridge.self, forKeyedSubscript: "Layer")

--- a/PrototopeJSBridge/MathBridge.swift
+++ b/PrototopeJSBridge/MathBridge.swift
@@ -12,7 +12,7 @@ import JavaScriptCore
 
 public struct MathBridge: BridgeType {
 	public static func addToContext(context: JSContext) {
-		let interpolateTrampoline: @objc_block NSDictionary -> Double = { args in
+		let interpolateTrampoline: @convention(block) NSDictionary -> Double = { args in
 			Prototope.interpolate(
 				from: (args["from"] as! Double?) ?? 0,
 				to: (args["to"] as! Double?) ?? 0,
@@ -21,7 +21,7 @@ public struct MathBridge: BridgeType {
 		}
 		context.setFunctionForKey("interpolate", fn: interpolateTrampoline)
 
-		let mapTrampoline: @objc_block NSDictionary -> Double = { args in
+		let mapTrampoline: @convention(block) NSDictionary -> Double = { args in
 			let fromInterval = (args["fromInterval"] as! [Double]?) ?? [0, 0]
 			let toInterval = (args["toInterval"] as! [Double]?) ?? [0, 0]
 			return Prototope.map(
@@ -32,7 +32,7 @@ public struct MathBridge: BridgeType {
 		}
 		context.setFunctionForKey("map", fn: mapTrampoline)
 
-		let clipTrampoline: @objc_block NSDictionary -> Double = { args in
+		let clipTrampoline: @convention(block) NSDictionary -> Double = { args in
 			Prototope.clip(
 				(args["value"] as! Double?) ?? 0,
 				min: (args["min"] as! Double?) ?? 0,
@@ -41,14 +41,14 @@ public struct MathBridge: BridgeType {
 		}
 		context.setFunctionForKey("clip", fn: clipTrampoline)
 		
-		let pixelAwareCeil: @objc_block NSDictionary -> Double = { args in
+		let pixelAwareCeil: @convention(block) NSDictionary -> Double = { args in
 			Prototope.pixelAwareCeil(
 				(args["value"] as! Double?) ?? 0
 			)
 		}
 		context.setFunctionForKey("pixelAwareCeil", fn: pixelAwareCeil)
 		
-		let pixelAwareFloor: @objc_block NSDictionary -> Double = { args in
+		let pixelAwareFloor: @convention(block) NSDictionary -> Double = { args in
 			Prototope.pixelAwareFloor(
 				(args["value"] as! Double?) ?? 0
 			)

--- a/PrototopeJSBridge/MathBridge.swift
+++ b/PrototopeJSBridge/MathBridge.swift
@@ -53,6 +53,6 @@ public struct MathBridge: BridgeType {
 				(args["value"] as! Double?) ?? 0
 			)
 		}
-		context.setFunctionForKey("pixelAwareFloor", fn: pixelAwareCeil)
+		context.setFunctionForKey("pixelAwareFloor", fn: pixelAwareFloor)
 	}
 }

--- a/PrototopeJSBridge/ScrollLayerBridge.swift
+++ b/PrototopeJSBridge/ScrollLayerBridge.swift
@@ -25,7 +25,7 @@ import JavaScriptCore
 }
 
 
-@objc public class ScrollLayerBridge: LayerBridge, ScrollLayerJSExport, BridgeType {
+@objc public class ScrollLayerBridge: LayerBridge, ScrollLayerJSExport {
 	var scrollLayer: ScrollLayer { return layer as! ScrollLayer }
 	
 	public override class func addToContext(context: JSContext) {

--- a/PrototopeJSBridge/ShapeLayerBridge.swift
+++ b/PrototopeJSBridge/ShapeLayerBridge.swift
@@ -27,7 +27,7 @@ import JavaScriptCore
     var lineJoinStyle: JSValue { get set }
 }
 
-@objc public class ShapeLayerBridge: LayerBridge, ShapeLayerJSExport, LayerJSExport, BridgeType {
+@objc public class ShapeLayerBridge: LayerBridge, ShapeLayerJSExport {
     var shapeLayer: ShapeLayer { return layer as! ShapeLayer }
     
     public override class func addToContext(context: JSContext) {

--- a/PrototopeJSBridge/SpeechBridge.swift
+++ b/PrototopeJSBridge/SpeechBridge.swift
@@ -25,7 +25,7 @@ import JavaScriptCore
 }
 
 
-let sayTrampoline: @objc_block JSValue -> Void = { args in
+let sayTrampoline: @convention(block) JSValue -> Void = { args in
 	let text = args.valueForProperty("text")
 	
 	if !text.isUndefined {
@@ -35,6 +35,6 @@ let sayTrampoline: @objc_block JSValue -> Void = { args in
 }
 
 
-let shhhTrampoline: @objc_block JSValue -> Void = { args in
+let shhhTrampoline: @convention(block) JSValue -> Void = { args in
 	Speech.shhh()
 }

--- a/PrototopeJSBridge/SpeechBridge.swift
+++ b/PrototopeJSBridge/SpeechBridge.swift
@@ -28,7 +28,7 @@ import JavaScriptCore
 let sayTrampoline: @objc_block JSValue -> Void = { args in
 	let text = args.valueForProperty("text")
 	
-	if !text.isUndefined() {
+	if !text.isUndefined {
 		Speech.say(text.toString())
 	}
 

--- a/PrototopeJSBridge/TextLayerBridge.swift
+++ b/PrototopeJSBridge/TextLayerBridge.swift
@@ -21,7 +21,7 @@ import JavaScriptCore
 	func alignWithBaselineOf(layer: TextLayerJSExport)
 }
 
-@objc public class TextLayerBridge: LayerBridge, TextLayerJSExport, BridgeType {
+@objc public class TextLayerBridge: LayerBridge, TextLayerJSExport {
 	var textLayer: TextLayer { return layer as! TextLayer }
 
 	public override class func addToContext(context: JSContext) {

--- a/PrototopeJSBridge/TimingBridge.swift
+++ b/PrototopeJSBridge/TimingBridge.swift
@@ -15,10 +15,10 @@ public class TimingBridge: BridgeType {
     	let timestampObject = JSValue(newObjectInContext: context)
     	context.setObject(timestampObject, forKeyedSubscript: "Timestamp")
 
-    	let currentTimestampFunction: @objc_block Void -> Double = { return Prototope.Timestamp.currentTimestamp.nsTimeInterval }
+    	let currentTimestampFunction: @convention(block) Void -> Double = { return Prototope.Timestamp.currentTimestamp.nsTimeInterval }
     	timestampObject.setFunctionForKey("currentTimestamp", fn: currentTimestampFunction)
 
-    	let afterDurationFunction: @objc_block (Double, JSValue) -> Void = { duration, callable in
+    	let afterDurationFunction: @convention(block) (Double, JSValue) -> Void = { duration, callable in
     		Prototope.afterDuration(duration) {
     			callable.callWithArguments([])
 				return

--- a/PrototopeJSBridge/TunableBridge.swift
+++ b/PrototopeJSBridge/TunableBridge.swift
@@ -12,7 +12,7 @@ import JavaScriptCore
 
 public struct TunableBridge: BridgeType {
 	public static func addToContext(context: JSContext) {
-		let tunableTrampoline: @objc_block JSValue -> NSNumber = { TunableBridge.tunable($0) }
+		let tunableTrampoline: @convention(block) JSValue -> NSNumber = { TunableBridge.tunable($0) }
 		context.setFunctionForKey("tunable", fn: tunableTrampoline)
 	}
 

--- a/PrototopeJSBridge/TunableBridge.swift
+++ b/PrototopeJSBridge/TunableBridge.swift
@@ -23,11 +23,11 @@ public struct TunableBridge: BridgeType {
 		let maxValue = args.objectForKeyedSubscript("max")
 		let maintainValue = args.objectForKeyedSubscript("changeHandler")
 
-		let name = nameValue.isUndefined() ? nil : nameValue.toString()
-		let defaultValue = defaultValueValue.isUndefined() ? nil : defaultValueValue.toNumber()
-		let min: Double? = minValue.isUndefined() ? nil : minValue.toDouble()
-		let max: Double? = maxValue.isUndefined() ? nil : maxValue.toDouble()
-		let maintain: JSValue? = maintainValue.isUndefined() ? nil : maintainValue
+		let name = nameValue.isUndefined ? nil : nameValue.toString()
+		let defaultValue = defaultValueValue.isUndefined ? nil : defaultValueValue.toNumber()
+		let min: Double? = minValue.isUndefined ? nil : minValue.toDouble()
+		let max: Double? = maxValue.isUndefined ? nil : maxValue.toDouble()
+		let maintain: JSValue? = maintainValue.isUndefined ? nil : maintainValue
 
 		if let name = name {
 			if let defaultValue = defaultValue {

--- a/PrototopeJSBridge/VideoLayerBridge.swift
+++ b/PrototopeJSBridge/VideoLayerBridge.swift
@@ -17,7 +17,7 @@ import JavaScriptCore
 }
 
 
-@objc public class VideoLayerBridge: LayerBridge, VideoLayerJSExport, BridgeType {
+@objc public class VideoLayerBridge: LayerBridge, VideoLayerJSExport {
 	var videoLayer: VideoLayer { return layer as! VideoLayer }
 	
 	public override class func addToContext(context: JSContext) {


### PR DESCRIPTION
This patch lets you create an `Image` by rendering a given string (with optional `font` and `textColor` parameters) into a buffer.

This is useful if you need to make an image from text (in particular, emoji) for things like particles, or if you need a text layer and you want to add touch handling to it, but you can’t because of #41 

This should be looked at after Swift 2 changes are merged in (#108)