### PR TITLE
Apple Pencil + 3D touch support

### DIFF
--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -2625,6 +2625,7 @@
 				);
 				INFOPLIST_FILE = Prototope/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -2649,6 +2650,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Prototope/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-lc++",

--- a/Prototope.xcodeproj/project.pbxproj
+++ b/Prototope.xcodeproj/project.pbxproj
@@ -2364,7 +2364,7 @@
 				);
 				INFOPLIST_FILE = PrototopeJSBridge/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2388,7 +2388,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = PrototopeJSBridge/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Prototope/Gesture.swift
+++ b/Prototope/Gesture.swift
@@ -23,14 +23,14 @@ public struct TouchSample: SampleType {
 	
 	
 	/** The force of the touch. Available only for certain devices (3D touch devices like iPhone 6S or Apple Pencil). */
-	public let force: Double
+	public let force: Double?
 
 	/** The location of the touch sample, converted into a target layer's coordinate system. */
 	public func locationInLayer(layer: Layer) -> Point {
 		return layer.convertGlobalPointToLocalPoint(globalLocation)
 	}
 
-	public init(globalLocation: Point, preciseGlobalLocation: Point? = nil, timestamp: Timestamp, force: Double = 0.0) {
+	public init(globalLocation: Point, preciseGlobalLocation: Point? = nil, timestamp: Timestamp, force: Double? = nil) {
 		self.globalLocation = globalLocation
 		self.preciseGlobalLocation = preciseGlobalLocation ?? globalLocation
 		self.timestamp = timestamp
@@ -706,6 +706,6 @@ extension TouchSample {
 		globalLocation = Point(touch.locationInView(nil))
 		preciseGlobalLocation = Point(touch.preciseLocationInView(nil))
 		timestamp = Timestamp(touch.timestamp)
-		force = Double(touch.force)
+		force = UIScreen.mainScreen().traitCollection.forceTouchCapability == .Available ? Double(touch.force) : nil
 	}
 }

--- a/Prototope/Gesture.swift
+++ b/Prototope/Gesture.swift
@@ -14,18 +14,27 @@ import UIKit
 public struct TouchSample: SampleType {
 	/** The location of the touch sample in the root layer's coordinate system. */
 	public let globalLocation: Point
+	
+	/** The precise location of the touch sample in the root layer's coordinate system. This should only be used for Stylus, not finger, input. */
+	public let preciseGlobalLocation: Point
 
 	/** The time at which the touch arrived. */
 	public let timestamp: Timestamp
+	
+	
+	/** The force of the touch. Available only for certain devices (3D touch devices like iPhone 6S or Apple Pencil). */
+	public let force: Double
 
 	/** The location of the touch sample, converted into a target layer's coordinate system. */
 	public func locationInLayer(layer: Layer) -> Point {
 		return layer.convertGlobalPointToLocalPoint(globalLocation)
 	}
 
-	public init(globalLocation: Point, timestamp: Timestamp) {
+	public init(globalLocation: Point, preciseGlobalLocation: Point? = nil, timestamp: Timestamp, force: Double = 0.0) {
 		self.globalLocation = globalLocation
+		self.preciseGlobalLocation = preciseGlobalLocation ?? globalLocation
 		self.timestamp = timestamp
+		self.force = force
 	}
 }
 
@@ -695,6 +704,8 @@ public func ==(lhs: _GestureType,rhs: _GestureType) -> Bool {
 extension TouchSample {
 	init(_ touch: UITouch) {
 		globalLocation = Point(touch.locationInView(nil))
+		preciseGlobalLocation = Point(touch.preciseLocationInView(nil))
 		timestamp = Timestamp(touch.timestamp)
+		force = Double(touch.force)
 	}
 }

--- a/PrototopeJSBridge/GestureBridge.swift
+++ b/PrototopeJSBridge/GestureBridge.swift
@@ -15,7 +15,9 @@ import JavaScriptCore
 @objc public protocol TouchSampleJSExport: JSExport {
 	init?(args: JSValue)
 	var globalLocation: PointJSExport { get }
+	var preciseGlobalLocation: PointJSExport { get }
 	var timestamp: Double { get }
+	var force: Double { get }
 	func locationInLayer(layer: LayerJSExport) -> PointJSExport
 }
 
@@ -48,7 +50,11 @@ import JavaScriptCore
 	}
 
 	public var globalLocation: PointJSExport { return PointBridge(touchSample.globalLocation) }
+	public var preciseGlobalLocation: PointJSExport { return PointBridge(touchSample.preciseGlobalLocation) }
+	
 	public var timestamp: Double { return touchSample.timestamp.nsTimeInterval }
+	public var force: Double { return touchSample.force }
+	
 	public func locationInLayer(layer: LayerJSExport) -> PointJSExport {
 		return PointBridge(touchSample.locationInLayer((layer as JSExport as! LayerBridge).layer))
 	}


### PR DESCRIPTION
This adds some basic Apple Pencil + 3D touch support to `TouchSample`, namely:

- `preciseGlobalLocation`, which gives very accurate touch locations for stylus touches
- `force`, which gives the pressure of the Apple Pencil touches. I think this also works for 3D touch but I don’t have a device to test on

The properties are also bridged to JS.

This PR also bumps the deployment targets for both Prototope and the JS bridge to `9.1` to take advantage of the new API.

In the future, it might make sense to give stylus input its own Sample type (for things like angles, estimated precise locations, etc).

fixes #104 and #103 